### PR TITLE
adding --debug by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Options:
     --live-port     the LiveReload port, default 35729
 ```
 
+By default, the `--debug` option will be sent to watchify (for source maps). If this is unwanted, you can use `--no-debug` or `--debug=false` to disable source maps.
+
 ## Script Injection
 
 [![screenshot](http://i.imgur.com/LJP7d9I.png)](https://www.youtube.com/watch?v=cfgeN3G_Gl0)

--- a/lib/budo.js
+++ b/lib/budo.js
@@ -14,8 +14,10 @@ module.exports = function(watchifyArgs, opt) {
     
     var emitter = new Emitter()
     
-    //patch watchify args with new outfile
+    //patch watchify args with new outfile and default debug
     setOutfile(watchifyArgs, output.from)
+    setDebug(watchifyArgs, opt.d || opt.debug)
+    
     //spin up watchify instance
     var watchProc = watchify(watchifyArgs)
     
@@ -68,5 +70,41 @@ module.exports = function(watchifyArgs, opt) {
             arglist.push(file)
         } else 
             arglist[idx+1] = file
+    }
+
+    //Supports various debug features
+    //    ['--no-debug'] (from minimist parsing, which browserify uses)
+    //    ['--debug=false']
+    //    ['--debug', 'false']
+    //    ['-d', 'false']
+    //Need to remove the debug flag entirely from args otherwise browserify
+    //will use source maps
+    function setDebug(arglist, enabled) {
+        enabled = enabled !== false && enabled !== 'false'
+        
+        //user can disable debug
+        if (enabled === false) { 
+            removeDebug(arglist)
+        } 
+        //by default, we want to enable debug
+        else {
+            var idx1 = arglist.indexOf('-d')
+            var idx2 = arglist.indexOf('--debug')
+            if (idx1 === -1 && idx2 === -1)
+                arglist.push('-d')
+        }
+    }
+
+    function removeDebug(arglist) {
+        var args = ['-d', '--debug', '--debug=false']
+        args.forEach(function(arg) {
+            var idx = arglist.indexOf(arg)
+            if (idx === -1 || String(arglist[idx+1]) === 'true')
+                return
+            if (String(arglist[idx+1]) === 'false')
+                arglist.splice(idx, 2)
+            else
+                arglist.splice(idx, 1)
+        })
     }
 }

--- a/test/test-simple.js
+++ b/test/test-simple.js
@@ -44,7 +44,7 @@ test('should run on available port', function(t) {
 test('should get a bundle.js', function(t) {
     var cwd = path.resolve(__dirname, '..')
     runBundleMatch(t, { 
-        watchify: ['app.js', '-v', '-o', 'bundle-expected.js'],
+        watchify: ['app.js', '-v', '-o', 'bundle-expected.js', '-d'],
         budo: ['app.js'],
     })
 })
@@ -52,7 +52,7 @@ test('should get a bundle.js', function(t) {
 test('entry mapping to bundle2.js', function(t) {
     var cwd = path.resolve(__dirname, '..')
     runBundleMatch(t, { 
-        watchify: ['app', '-v', '-o', 'bundle-expected.js'],
+        watchify: ['app', '-v', '-o', 'bundle-expected.js', '-d'],
         budo: ['app:bundle2.js'],
         to: 'bundle2.js'
     })
@@ -61,8 +61,16 @@ test('entry mapping to bundle2.js', function(t) {
 test('should get a bundle.js with --outfile', function(t) {
     var cwd = path.resolve(__dirname, '..')
     runBundleMatch(t, { 
-        watchify: ['app.js', '-v', '-o', 'bundle-expected.js'],
+        watchify: ['app.js', '-v', '-o', 'bundle-expected.js', '-d'],
         budo: ['app.js', '-o', 'bundle.js']
+    })
+})
+
+test('should disable source maps with --no-debug', function(t) {
+    var cwd = path.resolve(__dirname, '..')
+    runBundleMatch(t, { 
+        watchify: ['app.js', '-v', '-o', 'bundle-expected.js'],
+        budo: ['app.js', '-o', 'bundle.js', '--no-debug']
     })
 })
 
@@ -70,7 +78,7 @@ test('should get a bundle.js with --dir', function(t) {
     var cwd = path.resolve(__dirname, '..')
     runBundleMatch(t, { 
         cwd: cwd,
-        watchify: ['test/app.js', '-v', '-o', 'test/bundle-expected.js'],
+        watchify: ['test/app.js', '-v', '-o', 'test/bundle-expected.js', '-d'],
         budo: ['test/app.js', '-o', 'bundle.js', '--dir', 'test']
     })
 })


### PR DESCRIPTION
Source maps enabled by default. Can be disabled with any of the following:

```
-d false
--debug=false
--debug false
--no-debug (part of minimist's parsing engine)
```

Squashed commits:
[9a739db] fixing various edge cases for debug