### PR TITLE
Source cleanup, watchify@3.0, decoupling LiveReload/watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Options:
     --port          the port to run, default 9966
     --host          the host, default "localhost"
     --dir           the directory to serve, and the base for --outfile
-    --live          enable LiveReload integration
-    --live-plugin   enable LiveReload but do not inject script tag
+    --live          enable LiveReload integration with a script tag
+    --live-plugin   enable LiveReload for use with a browser plugin
     --live-port     the LiveReload port, default 35729
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ PRs/suggestions/comments welcome. Props to [@caspervonb](https://twitter.com/cas
 
 - [basic usage](docs/basics.md)
 - [comparisons](docs/comparisons.md)
+- [programmatic usage (Gulp, Grunt)](docs/programmatic-usage.md)
 - [error reporting](docs/errors.md)
 - [running tests and examples](docs/tests-and-examples.md)
 - [script injection with budo-chrome](https://github.com/mattdesl/budo-chrome)
-- [programmatic usage (Gulp, Grunt)](docs/programmatic-usage.md)
 - [rapid prototyping with budō and wzrd](http://mattdesl.svbtle.com/rapid-prototyping)
 
 ## usage

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Usage:
     budo [entries] [opts]
 
 Options:
+    --help, -h      show help message
     --outfile, -o   path to output bundle
     --port          the port to run, default 9966
     --host          the host, default "localhost"

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -5,14 +5,30 @@
 
 var args = process.argv.slice(2)
 var opts = require('minimist')(args)
-var portfinder = require('portfinder')
+var getport = require('getport')
 
 var entries = opts._
 opts.stream = process.stdout
 delete opts._
 
-portfinder.basePort = opts.port || opts.p || 9966
-portfinder.getPort(function(err, port) {
+var showHelp = opts.h || opts.help
+
+if (!showHelp && (!entries || entries.filter(Boolean).length === 0)) {
+    console.error('ERROR: no entry scripts specified\n  use --help for examples')
+    return
+}
+
+if (showHelp) {
+    var vers = require('../package.json').version
+    console.log('budo '+vers, '\n')
+    var help = require('path').join(__dirname, 'help.txt')
+    require('fs').createReadStream(help)
+        .pipe(process.stdout)
+    return
+}
+
+var basePort = opts.port || opts.p || 9966
+getport(basePort, function(err, port) {
     if (err) {
         console.error("Could not find port", err)
         process.exit(1)

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
-//Starts up budo with some logging,
-//also listens for live reload events
+//Starts budo with stdout
+//Handles --help and error messaging
+//Uses auto port-finding
 
 var args = process.argv.slice(2)
 var opts = require('minimist')(args)

--- a/bin/help.txt
+++ b/bin/help.txt
@@ -2,6 +2,7 @@ Usage:
   budo index.js [opts] [browserify opts]
 
 Options:
+    --help, -h      show help message
     --outfile, -o   path to output bundle
     --port          the port to run, default 9966
     --host          the host, default "localhost"

--- a/bin/help.txt
+++ b/bin/help.txt
@@ -1,0 +1,16 @@
+Usage:
+  budo index.js [opts] [browserify opts]
+
+Options:
+    --outfile, -o   path to output bundle
+    --port          the port to run, default 9966
+    --host          the host, default "localhost"
+    --dir           the directory to serve, and the base for --outfile
+    --live          enable LiveReload integration
+    --live-plugin   enable LiveReload but do not inject script tag
+    --live-port     the LiveReload port, default 35729
+
+Examples:
+  budo index.js --live --dir app/ --outfile bundle.js
+  budo index.js --verbose --transform brfs
+  budo index.js:test.js --port 3000

--- a/docs/programmatic-usage.md
+++ b/docs/programmatic-usage.md
@@ -60,11 +60,11 @@ If live reload is enabled (i.e. through `live` or `live-plugin`), this will send
 
 #### `b.live([opt])`
 
-If `live` and `live-plugin` were not specified, you can manually enable the LiveReload server with the specified options: `port` (default 35729) and `host` (default to the `host` argument provided to budo, or `localhost`). 
+If `live` and `live-plugin` were not specified, you can manually enable the LiveReload server with the specified options: `port` (default 35729) and `host` (default to the `host` argument provided to budo, or `localhost`). You can also specify `plugin: true` if you do not want the LiveReload snippet injected into the HTML. 
 
 #### `b.watch([globs, chokidarOpts])`
 
-If `live` and `live-plugin` were not specified, you can manually enabe [chokidar's](https://github.com/paulmillr/chokidar) file watching with the specified `globs` (array or string) and options. It will default to watching HTML, CSS, and the watchified bundle.
+If `live` and `live-plugin` were not specified, you can manually enabe [chokidar's](https://github.com/paulmillr/chokidar) file watching with the specified `globs` (array or string) and options. It will default to watching `**/*.{html,css}` and the watchified bundle.
 
 Example of using `live()` and `watch()` together.
 

--- a/docs/programmatic-usage.md
+++ b/docs/programmatic-usage.md
@@ -60,7 +60,7 @@ If live reload is enabled (i.e. through `live` or `live-plugin`), this will send
 
 #### `b.live([opt])`
 
-If `live` and `live-plugin` were not specified, you can manually enable the LiveReload server with the specified options: `port` (default 35729) and `host` (default to the `host` argument provided to budo, or `localhost`). You can also specify `plugin: true` if you do not want the LiveReload snippet injected into the HTML. 
+If `live` and `live-plugin` were not specified, you can manually enable the LiveReload server with the specified options object: `port` (default 35729) and `host` (default to the `host` argument provided to budo, or `localhost`). You can also specify `plugin: true` if you do not want the LiveReload snippet injected into the HTML. 
 
 #### `b.watch([globs, chokidarOpts])`
 
@@ -70,17 +70,18 @@ Example of using `live()` and `watch()` together.
 
 ```js
 var budo = require('budo')
+var path = require('path')
 var app = budo('index.js')
 
 app
-  //enable file watching
-  .watch('*.css', { usePolling: true })
+  //enable additional watching with chokidar options
+  .watch('*.css', { interval: 300, usePolling: true })
   //start LiveReload server
   .live()
   //handle file events
   .on('watch', function(type, file) {
     //tell LiveReload to inject some CSS
-    if (type === 'change')
+    if (path.extname(file) === '.css')
       app.reload(file)
   })
 ``` 

--- a/docs/programmatic-usage.md
+++ b/docs/programmatic-usage.md
@@ -43,21 +43,47 @@ Called once the budo server connects. The callback is passed an `event` object t
   dir: 'app',                    //the working directory
   host: 'localhost',             //defaults to localhost
   port: 9966,                    //the port we're running on
-  
-  //also provides a function to close the budo instance
-  close()
 }
 ```
 
-It's recommended to use `glob` instead of `from` if you intend to watch the `bundle.js` for file changes (e.g. determining when the bundle is ready to launch the browser). This is due to some issues with OSX temp dir file watching.
-
 #### `b.on('watch')`
 
-If `live` or `live-plugin` options were passed, this event will be triggered after a file change or addition is made (such as bundle.js or themes.css). The parameters will be `(eventType, file)` where `eventType` is typically "add" or "change".
+If file watching is enabeld (i.e. through `live` or `live-plugin`), this event will be triggered after a file change or addition is made (such as bundle.js or themes.css). The parameters will be `(eventType, file)` where `eventType` could be "add", "change", "unlink", etc.
 
-#### `b.on('reload')
+#### `b.on('reload')`
 
-If `live` or `live-plugin` options were passed, this event will be triggered after the LiveReload has been sent. The parameter is `file`, the file path being submitted to the LiveReload server.
+If live reload is enabeld (i.e. through `live` or `live-plugin`), this event will be triggered after the LiveReload has been sent. The parameter is `file`, the file path being submitted to the LiveReload server.
+
+#### `b.reload(path)`
+
+If live reload is enabled (i.e. through `live` or `live-plugin`), this will send a LiveReload event to the given path and then trigger the `"reload"` event.
+
+#### `b.live([opt])`
+
+If `live` and `live-plugin` were not specified, you can manually enable the LiveReload server with the specified options: `port` (default 35729) and `host` (default to the `host` argument provided to budo, or `localhost`). 
+
+#### `b.watch([globs, chokidarOpts])`
+
+If `live` and `live-plugin` were not specified, you can manually enabe [chokidar's](https://github.com/paulmillr/chokidar) file watching with the specified `globs` (array or string) and options. It will default to watching HTML, CSS, and the watchified bundle.
+
+Example of using `live()` and `watch()` together.
+
+```js
+var budo = require('budo')
+var app = budo('index.js')
+
+app
+  //enable file watching
+  .watch('*.css', { usePolling: true })
+  //start LiveReload server
+  .live()
+  //handle file events
+  .on('watch', function(type, file) {
+    //tell LiveReload to inject some CSS
+    if (type === 'change')
+      app.reload(file)
+  })
+``` 
 
 # gulp & grunt
 

--- a/docs/programmatic-usage.md
+++ b/docs/programmatic-usage.md
@@ -64,7 +64,9 @@ If `live` and `live-plugin` were not specified, you can manually enable the Live
 
 #### `b.watch([globs, chokidarOpts])`
 
-If `live` and `live-plugin` were not specified, you can manually enabe [chokidar's](https://github.com/paulmillr/chokidar) file watching with the specified `globs` (array or string) and options. It will default to watching `**/*.{html,css}` and the watchified bundle.
+If `live` and `live-plugin` were not specified, you can manually enabe [chokidar's](https://github.com/paulmillr/chokidar) file watching with the specified `globs` (array or string) and options. 
+
+`globs` defaults to watching `**/*.{html,css}` and the watchified bundle. `chokidarOpts` defaults to the options passed to the budo constructor.
 
 Example of using `live()` and `watch()` together.
 
@@ -74,7 +76,7 @@ var path = require('path')
 var app = budo('index.js')
 
 app
-  //enable additional watching with chokidar options
+  //listen to CSS changes
   .watch('*.css', { interval: 300, usePolling: true })
   //start LiveReload server
   .live()
@@ -86,13 +88,9 @@ app
   })
 ``` 
 
-# gulp & grunt
+# build tools
 
-Budo works without gulp and grunt, but you may want to wrap it within the same build environment for consistency.
-
-### simple recipe
-
-A simple case of budo within gulp might look like this:
+Budo doesn't need a Grunt or Gulp specific plugin to work, but you may choose to wrap it within your favourite task runner for consistency. A simple case might look like this:
 
 ```js
 var gulp = require('gulp')
@@ -101,8 +99,8 @@ var budo = require('budo')
 //start our local development server
 gulp.task('dev', function(cb) {
   budo('index.js')
-    .on('connect', function(app) {
-      console.log("Server started at "+app.uri)
+    .on('connect', function(ev) {
+      console.log("Server started at "+ev.uri)
     })
     .on('exit', cb)
 })
@@ -110,38 +108,8 @@ gulp.task('dev', function(cb) {
 
 Now running `gulp dev` will spin up a server on 9966, spawn watchify, and incrementally rebundle during development. It will stub out an `index.html` and write `bundle.js` to a temp directory.
 
-### advanced recipes
+#### integrations
 
-The following script shows how you can include a few more features to the task:
-
-- uses LiveReload on bundle change
-- uses `babelify` for ES6 transpiling 
-- uses `errorify` to display syntax errors in the browser
-- pretty-prints server requests to stdout with [garnish](https://github.com/mattdesl/garnish)
-
-```js
-var gulp = require('gulp')
-var budo = require('budo')
-var garnish = require('garnish')
-
-//advanced example
-gulp.task('default', function(cb) {
-  //using garnish for pretty-printing server requests
-  var pretty = garnish()
-  pretty.pipe(process.stdout)
-
-  budo('index.js', {
-    live: true,            //live reload
-    stream: pretty,        //output stream
-    port: 8000,            //the port to serve on
-    plugin: 'errorify',    //nicer errors during dev
-    transform: 'babelify'  //ES6 transpiling
-  }).on('exit', cb)
-})
-```
-
-Note that `babelify` and `errorify` need to be saved as local devDependencies.
-
-### demo
-
-[budo-gulp-starter](https://github.com/mattdesl/budo-gulp-starter) demonstrates some more complex applications of budo and gulp.
+- [gulp](https://github.com/mattdesl/budo-gulp-starter)
+- [npm scripts](https://gist.github.com/mattdesl/b6990e7c7221c9cc05aa)
+- [LiveReactLoad](https://gist.github.com/mattdesl/2aa5b45ed1f230635a04)

--- a/example/app.js
+++ b/example/app.js
@@ -14,15 +14,15 @@ img.src = 'baboon.png'
 var time = 0
 
 require('raf-loop')(function(dt) {
-    var width = window.innerWidth,
-        height = window.innerHeight
+    var width = ctx.canvas.width,
+        height = ctx.canvas.height
     ctx.clearRect(0, 0, width, height)
 
     time += dt/1000
 
     ctx.save()
     ctx.scale(dpr, dpr)
-    ctx.fillRect(Math.sin(time)*50 + 200, 35, 150, 150) 
+    ctx.fillRect(Math.sin(time)*50 + 300, 235, 150, 150) 
     ctx.fillText("from browserify!", 40, 40)
     if (img.width > 0 || img.height > 0)
         ctx.drawImage(img, 50, 50)

--- a/index.js
+++ b/index.js
@@ -6,74 +6,90 @@ var Emitter = require('events/')
 var getOutput = require('./lib/get-output')
 var wtch = require('wtch')
 
-var defaultGlob = '**/*.{html,css}'
-
 var budo = require('./lib/budo')
 
 module.exports = function(entry, opts) {
-    var argv = assign({}, opts)
+  var argv = assign({}, opts)
 
-    if (argv.stream) {
-        bole.output({
-            stream: argv.stream,
-            level: 'debug'
-        })
-    }
-
-    var emitter = new Emitter()
-    var watcher
-
-    var entries = Array.isArray(entry) ? entry : [ entry ]
-    entries = entries.filter(Boolean)
-    if (entries.length === 0) {
-        bail("No entry scripts specified!")
-        return emitter
-    }
-
-    argv.port = typeof argv.port === 'number' ? argv.port : 9966
-    argv.dir = argv.dir || process.cwd()
-    var outOpts = xtend(argv, { __to: entryMapping() })
-
-    getOutput(outOpts, function(err, output) {
-        if (err) {
-            bail("Error: Could not create temp bundle.js directory")
-            return emitter
-        }
-
-        //run watchify server
-        var app = budo(entries, output, argv)
-            .on('error', function(err2) {
-                var msg = "Error running budo on " + argv.port + ': ' + err2
-                bail(msg)
-            })
-            .on('exit', function() {
-                log.info('closing')
-                emitter.emit('exit')
-                if (watcher)
-                    watcher.close()
-            })
-            .on('connect', function() {
-                emitter.emit('connect', app)
-            })
+  if (argv.stream) {
+    bole.output({
+      stream: argv.stream,
+      level: 'debug'
     })
+  }
 
+  var emitter = new Emitter()
+  emitter.on('connect', setupLive)
+
+  var entries = Array.isArray(entry) ? entry : [entry]
+  entries = entries.filter(Boolean)
+  if (entries.length === 0) {
+    bail("No entry scripts specified!")
     return emitter
+  }
 
-    function entryMapping() {
-        var to
-        var first = entries[0]
-        var parts = first.split(':')
-        if (parts.length > 1 && parts[1].length > 0) {
-            var from = parts[0]
-            to = parts[1]
-            entries[0] = from
-        }
-        return to
+  argv.port = typeof argv.port === 'number' ? argv.port : 9966
+  argv.dir = argv.dir || process.cwd()
+  var outOpts = xtend(argv, {
+    __to: entryMapping()
+  })
+
+  getOutput(outOpts, function(err, output) {
+    if (err) {
+      bail("Error: Could not create temp bundle.js directory")
+      return emitter
     }
 
-    function bail(msg) {
-        process.nextTick(function() {
-            emitter.emit('error', new Error(msg))
+    //run watchify server
+    var app = budo(entries, output, argv)
+      .on('error', function(err2) {
+        var msg = "Error running budo on " + argv.port + ': ' + err2
+        bail(msg)
+      })
+      .on('exit', function() {
+        log.info('closing')
+        emitter.emit('exit')
+      })
+
+    app.on('connect', emitter.emit.bind(emitter, 'connect'))
+    app.on('watch', emitter.emit.bind(emitter, 'watch'))
+    app.on('reload', emitter.emit.bind(emitter, 'reload'))
+  })
+
+  return emitter
+
+  //if user requested live: true, set it up with some defaults
+  function setupLive(app) {
+    if (argv.live || argv['live-plugin']) {
+      app
+        .watch()
+        .live({ 
+          host: argv.host,
+          port: argv['live-port']
+        })
+        .on('watch', function(ev, file) {
+          if (ev === 'change' || ev === 'add') {
+            app.reload(file)
+          }
         })
     }
+  }
+
+  function entryMapping() {
+    var to
+    var first = entries[0]
+    var parts = first.split(':')
+    if (parts.length > 1 && parts[1].length > 0) {
+      var from = parts[0]
+      to = parts[1]
+      entries[0] = from
+    }
+    return to
+  }
+
+  function bail(msg) {
+    process.nextTick(function() {
+      emitter.emit('error', new Error(msg))
+    })
+  }
 }

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = function(entry, opts) {
     })
   }
 
-  var emitter = new Emitter()
+  var emitter = budo()
   emitter.on('connect', setupLive)
 
   var entries = Array.isArray(entry) ? entry : [entry]
@@ -41,27 +41,22 @@ module.exports = function(entry, opts) {
     }
 
     //run watchify server
-    var app = budo(entries, output, argv)
+    emitter._start(entries, output, argv)
       .on('error', function(err2) {
         var msg = "Error running budo on " + argv.port + ': ' + err2
         bail(msg)
       })
       .on('exit', function() {
         log.info('closing')
-        emitter.emit('exit')
       })
-
-    app.on('connect', emitter.emit.bind(emitter, 'connect'))
-    app.on('watch', emitter.emit.bind(emitter, 'watch'))
-    app.on('reload', emitter.emit.bind(emitter, 'reload'))
   })
 
   return emitter
 
   //if user requested live: true, set it up with some defaults
-  function setupLive(app) {
+  function setupLive() {
     if (argv.live || argv['live-plugin']) {
-      app
+      emitter
         .watch()
         .live({ 
           host: argv.host,
@@ -69,7 +64,7 @@ module.exports = function(entry, opts) {
         })
         .on('watch', function(ev, file) {
           if (ev === 'change' || ev === 'add') {
-            app.reload(file)
+            emitter.reload(file)
           }
         })
     }

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function(entry, opts) {
       level: 'debug'
     })
   }
-
+  
   var emitter = budo()
   emitter.on('connect', setupLive)
 

--- a/index.js
+++ b/index.js
@@ -53,29 +53,6 @@ module.exports = function(entry, opts) {
                     watcher.close()
             })
             .on('connect', function() {
-                var globs = app.glob
-                var liveOptions = { 
-                    port: argv['live-port'],
-                    livereload: false,
-                    event: 'all'
-                }
-
-                //enable LiveReload server as well
-                if (argv.live || argv['live-plugin']) {
-                    liveOptions.livereload = true
-
-                    //also listen to HTML/CSS
-                    globs = [defaultGlob, app.glob]
-                }
-                
-                //dispatches watch and LiveReload events
-                watcher = wtch(globs, liveOptions)
-                watcher.on('watch', function(ev, file) {
-                    if (app.from === file && (ev === 'add' || ev === 'change'))
-                        emitter.emit('bundle', file)
-                })
-                watcher.on('watch', emitter.emit.bind(emitter, 'watch'))
-                watcher.on('reload', emitter.emit.bind(emitter, 'reload'))
                 emitter.emit('connect', app)
             })
     })

--- a/lib/budo.js
+++ b/lib/budo.js
@@ -26,20 +26,28 @@ module.exports = function(entries, output, opt) {
   var watchifyProc
   var watcher
   var tinylr
-
+  var defaultGlobs
+  var defaultLiveOpts
+  
   //no-op until live() is enabled
-  emitter.reload = function() {}
+  emitter.reload = noop
 
   //enable file watch capabilities
   emitter.watch = function(glob, watchOpt) {
-    watcher = createFileWatch(emitter, glob, watchOpt)
+    watcher = createFileWatch(glob || defaultGlobs, watchOpt)
+    watcher.on('watch', emitter.emit.bind(emitter, 'watch'))
+    emitter.watch = noop
     return emitter
   }
 
   //enable live-reload capabilities
   emitter.live = function(liveOpt) {
-    tinylr = createTinylr(emitter, liveOpt)
-    emitter.reload = tinylr.reload.bind(tinylr)
+    tinylr = createTinylr(xtend(defaultLiveOpts, liveOpt))
+    emitter.reload = function(path) {
+      tinylr.reload(path)
+      emitter.emit('reload', path)
+    }
+    emitter.live = noop
     return emitter
   }
 
@@ -69,13 +77,14 @@ module.exports = function(entries, output, opt) {
       if (closed)
         return
 
+      handler()
+
+      //setup watchify; when it ends, close the server
       watchifyProc = watchify(watchifyArgs)
-        //when watchify ends, close the server
       watchifyProc.stderr.on('end', function() {
         emitter.close()
       })
-
-      handler()
+      emitter.emit('connect', emitter)
     })
 
 
@@ -96,17 +105,21 @@ module.exports = function(entries, output, opt) {
       uri: uri,
       port: port,
       host: hostname,
-      server: server
+      server: server,
+      'live-port': opt['live-port']
     }, output, {
       glob: glob
     })
 
-    if (opt.live || opt['live-plugin']) {
-      emitter.watch()
-      emitter.live()
+    //defaults for live() / watch() functions
+    defaultGlobs = ['**/*.{html,css}', emitter.glob]
+    defaultLiveOpts = {
+      port: emitter['live-port']
     }
+  }
 
-    emitter.emit('connect', emitter)
+  function noop() {
+    return emitter
   }
 }
 

--- a/lib/budo.js
+++ b/lib/budo.js
@@ -6,6 +6,8 @@ var assign = require('xtend/mutable')
 var http = require('./server').http
 var log = require('bole')('budo')
 var dargs = require('dargs')
+var createFileWatch = require('./file-watch')
+var createTinylr = require('./tinylr')
 
 module.exports = function(entries, output, opt) {
     opt = opt||{}
@@ -19,7 +21,40 @@ module.exports = function(entries, output, opt) {
 
     //spin up watchify instance
     var watchifyArgs = getWatchifyArgs(entries, output, opt)
-    var watchProc
+    var watchifyProc
+    var watcher
+    var tinylr
+
+    //no-op until live() is enabled
+    emitter.reload = function() {
+    }
+
+    //enable file watch capabilities
+    emitter.watch = function(glob, watchOpt) {
+        watcher = createFileWatch(emitter, glob, watchOpt)
+        return emitter
+    }
+
+    //enable live-reload capabilities
+    emitter.live = function(liveOpt) {
+        tinylr = createTinylr(emitter, liveOpt)
+        emitter.reload = tinylr.reload.bind(tinylr)
+        return emitter
+    }
+
+    emitter.close = function() {
+        if (closed) 
+            return
+        closed = true
+        if (watchifyProc)
+            watchifyProc.kill()
+        if (watcher)
+            watcher.close()
+        if (tinylr)
+            tinylr.close()
+        server.close()
+        emitter.emit('exit')
+    }
     
     var server = http(serverOpt)
         .on('error', function(err) {
@@ -33,24 +68,15 @@ module.exports = function(entries, output, opt) {
             if (closed) 
                 return
 
-            watchProc = watchify(watchifyArgs)
+            watchifyProc = watchify(watchifyArgs)
             //when watchify ends, close the server
-            watchProc.stderr.on('end', function() {
+            watchifyProc.stderr.on('end', function() {
                 emitter.close()
             })
 
             handler()
         })
         
-    emitter.close = function() {
-        if (closed) 
-            return
-        closed = true
-        if (watchProc)
-            watchProc.kill()
-        server.close()
-        emitter.emit('exit')
-    }
 
     return emitter
 
@@ -73,6 +99,9 @@ module.exports = function(entries, output, opt) {
             host: hostname,
             server: server
         }, output, { glob: glob })
+
+
+
         emitter.emit('connect', emitter)
     }
 }

--- a/lib/budo.js
+++ b/lib/budo.js
@@ -147,8 +147,8 @@ module.exports = function() {
     defaultGlobs = ['**/*.{html,css}', emitter.glob]
     defaultLiveOpts = {
       plugin: opt['live-plugin'],
-      port: emitter['live-port'],
-      script: opt['live-script']
+      host: opt.host,
+      port: emitter['live-port']
     }
   }
 

--- a/lib/budo.js
+++ b/lib/budo.js
@@ -19,33 +19,42 @@ module.exports = function(entries, output, opt) {
 
     //spin up watchify instance
     var watchifyArgs = getWatchifyArgs(entries, output, opt)
-    var watchProc = watchify(watchifyArgs)
+    var watchProc
     
     var server = http(serverOpt)
         .on('error', function(err) {
             emitter.emit('error', err)
         })
-        .listen(port, host, handler)
+        .listen(port, host, function(err) {
+            if (err) {
+                emitter.emit('error', new Error("Could not connect to server: " + err))
+                return 
+            }
+            if (closed) 
+                return
+
+            watchProc = watchify(watchifyArgs)
+            //when watchify ends, close the server
+            watchProc.stderr.on('end', function() {
+                emitter.close()
+            })
+
+            handler()
+        })
         
     emitter.close = function() {
-        if (closed) return
+        if (closed) 
+            return
         closed = true
-        watchProc.kill()
+        if (watchProc)
+            watchProc.kill()
         server.close()
         emitter.emit('exit')
     }
 
-    //when watchify ends, close the server
-    watchProc.stderr.on('end', function() {
-        emitter.close()
-    })
     return emitter
 
-    function handler(err) {
-        if (err) {
-            emitter.emit('error', new Error("Could not connect to server: " + err))
-            return 
-        }
+    function handler() {
         var hostname = (host||'localhost')
         var uri = "http://"+hostname+":"+port+"/"
         log.info("Server running at", uri)

--- a/lib/budo.js
+++ b/lib/budo.js
@@ -78,6 +78,8 @@ module.exports = function() {
     if (!started) {
       deferreds.push(emitter.live.bind(null, liveOpt))
     } else {
+      liveOpt = liveOpt||{}
+      server._live = !liveOpt.plugin
       tinylr = createTinylr(xtend(defaultLiveOpts, liveOpt))
       emitter.reload = function(path) {
         tinylr.reload(path)
@@ -144,7 +146,9 @@ module.exports = function() {
     //defaults for live() / watch() functions
     defaultGlobs = ['**/*.{html,css}', emitter.glob]
     defaultLiveOpts = {
-      port: emitter['live-port']
+      plugin: opt['live-plugin'],
+      port: emitter['live-port'],
+      script: opt['live-script']
     }
   }
 

--- a/lib/budo.js
+++ b/lib/budo.js
@@ -9,48 +9,86 @@ var dargs = require('dargs')
 var createFileWatch = require('./file-watch')
 var createTinylr = require('./tinylr')
 
-module.exports = function(entries, output, opt) {
-  opt = opt || {}
-
-  var port = opt.port || 9966
-  var host = opt.host
-  var serverOpt = xtend(opt, {
-    output: output
-  })
-
+module.exports = function() {
   var emitter = new Emitter()
+  var started = false
   var closed = false
 
-  //spin up watchify instance
-  var watchifyArgs = getWatchifyArgs(entries, output, opt)
   var watchifyProc
+  var server
   var watcher
   var tinylr
   var defaultGlobs
   var defaultLiveOpts
+  var deferreds = []
+
+  emitter._start = function(entries, output, opt) {
+    opt = opt || {}
+    var port = opt.port
+    var serverOpt = xtend(opt, {
+      output: output
+    })
+
+    server = http(serverOpt)
+      .on('error', function(err) {
+        emitter.emit('error', err)
+      })
+      .listen(port, opt.host, function(err) {
+        if (err) {
+          emitter.emit('error', new Error("Could not connect to server: " + err))
+          return
+        }
+
+        //setup "event" param for callback
+        assignOptions(output, opt)
+
+        //start watchify process
+        runWatchify(entries, output, opt)
+
+        started = true
+        emitter.emit('connect', emitter)
+
+        //if user wanted live() or watch() enabled
+        deferreds.forEach(function(func) {
+          func()
+        })
+        deferreds.length = 0
+      })
+    return emitter
+  }
   
   //no-op until live() is enabled
   emitter.reload = noop
 
   //enable file watch capabilities
   emitter.watch = function(glob, watchOpt) {
-    watcher = createFileWatch(glob || defaultGlobs, watchOpt)
-    watcher.on('watch', emitter.emit.bind(emitter, 'watch'))
-    emitter.watch = noop
+    if (!started) {
+      deferreds.push(emitter.watch.bind(null, glob, watchOpt))
+    }
+    else {
+      watcher = createFileWatch(glob || defaultGlobs, watchOpt)
+      watcher.on('watch', emitter.emit.bind(emitter, 'watch'))
+      emitter.watch = noop
+    }
     return emitter
   }
 
   //enable live-reload capabilities
   emitter.live = function(liveOpt) {
-    tinylr = createTinylr(xtend(defaultLiveOpts, liveOpt))
-    emitter.reload = function(path) {
-      tinylr.reload(path)
-      emitter.emit('reload', path)
+    if (!started) {
+      deferreds.push(emitter.live.bind(null, liveOpt))
+    } else {
+      tinylr = createTinylr(xtend(defaultLiveOpts, liveOpt))
+      emitter.reload = function(path) {
+        tinylr.reload(path)
+        emitter.emit('reload', path)
+      }
+      emitter.live = noop
     }
-    emitter.live = noop
     return emitter
   }
 
+  //close everything
   emitter.close = function() {
     if (closed)
       return
@@ -61,49 +99,41 @@ module.exports = function(entries, output, opt) {
       watcher.close()
     if (tinylr)
       tinylr.close()
-    server.close()
+    if (server)
+      server.close()
+    emitter.live = noop
+    emitter.watch = noop
     emitter.emit('exit')
   }
 
-  var server = http(serverOpt)
-    .on('error', function(err) {
-      emitter.emit('error', err)
-    })
-    .listen(port, host, function(err) {
-      if (err) {
-        emitter.emit('error', new Error("Could not connect to server: " + err))
-        return
-      }
-      if (closed)
-        return
-
-      handler()
-
-      //setup watchify; when it ends, close the server
-      watchifyProc = watchify(watchifyArgs)
-      watchifyProc.stderr.on('end', function() {
-        emitter.close()
-      })
-      emitter.emit('connect', emitter)
-    })
-
-
   return emitter
 
-  function handler() {
-    var hostname = (host || 'localhost')
-    var uri = "http://" + hostname + ":" + port + "/"
+  function runWatchify(entries, output, opt) {    
+    if (closed)
+      return
+
+    //setup watchify; when it ends, close the server
+    var watchifyArgs = getWatchifyArgs(entries, output, opt)
+    watchifyProc = watchify(watchifyArgs)
+    watchifyProc.stderr.on('end', function() {
+      emitter.close()
+    })
+  }
+
+  function assignOptions(output, opt) {
+    var hostname = (opt.host || 'localhost')
+    var uri = "http://" + hostname + ":" + opt.port + "/"
     log.info("Server running at", uri)
 
     //bug with chokidar@1.0.0-rc3
     //anything in OSX tmp dirs need a wildcard
     //to work with fsevents
-    var glob = output.tmp ? path.join(output.dir, '**.js') : output.from
+    var glob = output.tmp ? path.join(output.dir, '*.js') : output.from
 
     //add the uri / output to budo instance
     assign(emitter, {
       uri: uri,
-      port: port,
+      port: opt.port,
       host: hostname,
       server: server,
       'live-port': opt['live-port']

--- a/lib/budo.js
+++ b/lib/budo.js
@@ -45,7 +45,9 @@ module.exports = function() {
 
         //start watchify process
         runWatchify(entries, output, opt)
-
+        
+        started = true
+        
         //if user wanted live() or watch() enabled
         deferreds.forEach(function(func) {
           func()
@@ -53,7 +55,6 @@ module.exports = function() {
         deferreds.length = 0
 
         //finally, emit callback
-        started = true
         emitter.emit('connect', emitter)
       })
     return emitter

--- a/lib/budo.js
+++ b/lib/budo.js
@@ -10,128 +10,132 @@ var createFileWatch = require('./file-watch')
 var createTinylr = require('./tinylr')
 
 module.exports = function(entries, output, opt) {
-    opt = opt||{}
+  opt = opt || {}
 
-    var port = opt.port || 9966
-    var host = opt.host
-    var serverOpt = xtend(opt, { output: output })
-    
-    var emitter = new Emitter()
-    var closed = false
+  var port = opt.port || 9966
+  var host = opt.host
+  var serverOpt = xtend(opt, {
+    output: output
+  })
 
-    //spin up watchify instance
-    var watchifyArgs = getWatchifyArgs(entries, output, opt)
-    var watchifyProc
-    var watcher
-    var tinylr
+  var emitter = new Emitter()
+  var closed = false
 
-    //no-op until live() is enabled
-    emitter.reload = function() {
-    }
+  //spin up watchify instance
+  var watchifyArgs = getWatchifyArgs(entries, output, opt)
+  var watchifyProc
+  var watcher
+  var tinylr
 
-    //enable file watch capabilities
-    emitter.watch = function(glob, watchOpt) {
-        watcher = createFileWatch(emitter, glob, watchOpt)
-        return emitter
-    }
+  //no-op until live() is enabled
+  emitter.reload = function() {}
 
-    //enable live-reload capabilities
-    emitter.live = function(liveOpt) {
-        tinylr = createTinylr(emitter, liveOpt)
-        emitter.reload = tinylr.reload.bind(tinylr)
-        return emitter
-    }
-
-    emitter.close = function() {
-        if (closed) 
-            return
-        closed = true
-        if (watchifyProc)
-            watchifyProc.kill()
-        if (watcher)
-            watcher.close()
-        if (tinylr)
-            tinylr.close()
-        server.close()
-        emitter.emit('exit')
-    }
-    
-    var server = http(serverOpt)
-        .on('error', function(err) {
-            emitter.emit('error', err)
-        })
-        .listen(port, host, function(err) {
-            if (err) {
-                emitter.emit('error', new Error("Could not connect to server: " + err))
-                return 
-            }
-            if (closed) 
-                return
-
-            watchifyProc = watchify(watchifyArgs)
-            //when watchify ends, close the server
-            watchifyProc.stderr.on('end', function() {
-                emitter.close()
-            })
-
-            handler()
-        })
-        
-
+  //enable file watch capabilities
+  emitter.watch = function(glob, watchOpt) {
+    watcher = createFileWatch(emitter, glob, watchOpt)
     return emitter
+  }
 
-    function handler() {
-        var hostname = (host||'localhost')
-        var uri = "http://"+hostname+":"+port+"/"
-        log.info("Server running at", uri)
+  //enable live-reload capabilities
+  emitter.live = function(liveOpt) {
+    tinylr = createTinylr(emitter, liveOpt)
+    emitter.reload = tinylr.reload.bind(tinylr)
+    return emitter
+  }
 
-        //bug with chokidar@1.0.0-rc3
-        //anything in OSX tmp dirs need a wildcard
-        //to work with fsevents
-        var glob = output.tmp 
-            ? path.join(output.dir, '**.js')
-            : output.from
+  emitter.close = function() {
+    if (closed)
+      return
+    closed = true
+    if (watchifyProc)
+      watchifyProc.kill()
+    if (watcher)
+      watcher.close()
+    if (tinylr)
+      tinylr.close()
+    server.close()
+    emitter.emit('exit')
+  }
 
-        //add the uri / output to budo instance
-        assign(emitter, {
-            uri: uri,
-            port: port,
-            host: hostname,
-            server: server
-        }, output, { glob: glob })
+  var server = http(serverOpt)
+    .on('error', function(err) {
+      emitter.emit('error', err)
+    })
+    .listen(port, host, function(err) {
+      if (err) {
+        emitter.emit('error', new Error("Could not connect to server: " + err))
+        return
+      }
+      if (closed)
+        return
+
+      watchifyProc = watchify(watchifyArgs)
+        //when watchify ends, close the server
+      watchifyProc.stderr.on('end', function() {
+        emitter.close()
+      })
+
+      handler()
+    })
 
 
+  return emitter
 
-        emitter.emit('connect', emitter)
+  function handler() {
+    var hostname = (host || 'localhost')
+    var uri = "http://" + hostname + ":" + port + "/"
+    log.info("Server running at", uri)
+
+    //bug with chokidar@1.0.0-rc3
+    //anything in OSX tmp dirs need a wildcard
+    //to work with fsevents
+    var glob = output.tmp ? path.join(output.dir, '**.js') : output.from
+
+    //add the uri / output to budo instance
+    assign(emitter, {
+      uri: uri,
+      port: port,
+      host: hostname,
+      server: server
+    }, output, {
+      glob: glob
+    })
+
+    if (opt.live || opt['live-plugin']) {
+      emitter.watch()
+      emitter.live()
     }
+
+    emitter.emit('connect', emitter)
+  }
 }
 
 function getWatchifyArgs(entries, output, opt) {
-    //do not mutate original opts
-    opt = assign({}, opt)
+  //do not mutate original opts
+  opt = assign({}, opt)
 
-    //set output file
-    opt.outfile = output.from
-    delete opt.o
+  //set output file
+  opt.outfile = output.from
+  delete opt.o
 
-    //enable debug by default
-    if (opt.d !== false && opt.debug !== false) {
-        delete opt.d
-        opt.debug = true
-    } 
-    //if user explicitly disabled debug...
-    else if (opt.d === false || opt.debug === false) {
-        delete opt.d
-        delete opt.debug
-    }
+  //enable debug by default
+  if (opt.d !== false && opt.debug !== false) {
+    delete opt.d
+    opt.debug = true
+  }
+  //if user explicitly disabled debug...
+  else if (opt.d === false || opt.debug === false) {
+    delete opt.d
+    delete opt.debug
+  }
 
-    //clean up some possible collisions
-    delete opt.dir
-    delete opt.port
-    delete opt.host
-    delete opt.live
-    delete opt['live-port']
-    delete opt['live-script']
-    delete opt['live-plugin']
-    return entries.concat(dargs(opt))
+  //clean up some possible collisions
+  delete opt.dir
+  delete opt.port
+  delete opt.host
+  delete opt.live
+  delete opt['live-port']
+  delete opt['live-script']
+  delete opt['live-plugin']
+  return entries.concat(dargs(opt))
 }

--- a/lib/budo.js
+++ b/lib/budo.js
@@ -20,6 +20,7 @@ module.exports = function() {
   var tinylr
   var defaultGlobs
   var defaultLiveOpts
+  var defaultWatchOpts
   var deferreds = []
 
   emitter._start = function(entries, output, opt) {
@@ -45,14 +46,15 @@ module.exports = function() {
         //start watchify process
         runWatchify(entries, output, opt)
 
-        started = true
-        emitter.emit('connect', emitter)
-
         //if user wanted live() or watch() enabled
         deferreds.forEach(function(func) {
           func()
         })
         deferreds.length = 0
+
+        //finally, emit callback
+        started = true
+        emitter.emit('connect', emitter)
       })
     return emitter
   }
@@ -66,6 +68,8 @@ module.exports = function() {
       deferreds.push(emitter.watch.bind(null, glob, watchOpt))
     }
     else {
+      watchOpt = xtend(defaultWatchOpts, watchOpt)
+      watchOpt = getChokidarOpts(watchOpt) //transform to chokidar
       watcher = createFileWatch(glob || defaultGlobs, watchOpt)
       watcher.on('watch', emitter.emit.bind(emitter, 'watch'))
       emitter.watch = noop
@@ -145,6 +149,11 @@ module.exports = function() {
 
     //defaults for live() / watch() functions
     defaultGlobs = ['**/*.{html,css}', emitter.glob]
+    //watchify@3 has some extra options
+    defaultWatchOpts = {
+      poll: opt['poll'],
+      'ignore-watch': typeof opt['ignore-watch'] === 'undefined' ? opt.iw : opt['ignore-watch']
+    }
     defaultLiveOpts = {
       plugin: opt['live-plugin'],
       host: opt.host,
@@ -154,6 +163,25 @@ module.exports = function() {
 
   function noop() {
     return emitter
+  }
+}
+
+function getChokidarOpts(opt) {
+  //do not mutate original opts
+  opt = assign({}, opt)
+
+  if (opt.poll || opt.poll === 0) {
+    var interval = opt.poll
+    opt.usePolling = true
+    opt.interval = typeof interval === 'number' ? interval : 100
+    delete opt.poll
+  }
+  if (opt.ignoreWatch || typeof opt.ignoreWatch === 'string') {
+    opt.ignored = opt.ignoreWatch
+    delete opt.ignoreWatch
+  } else {
+    //otherwise let file-watch ignore some defaults
+    delete opt.ignored
   }
 }
 

--- a/lib/default-index.js
+++ b/lib/default-index.js
@@ -1,14 +1,14 @@
 var through2 = require('through2')
 
 module.exports = function(opt) {
-    var out = through2()
-    out.end([
-        '<!doctype html>',
-        '<head><meta charset="utf-8">',
-        '</head><body>',
-        '<script src="' + opt.outfile + '"></script>',
-        '</body>',
-        '</html>'
-    ].join(''))
-    return out
+  var out = through2()
+  out.end([
+    '<!doctype html>',
+    '<head><meta charset="utf-8">',
+    '</head><body>',
+    '<script src="' + opt.outfile + '"></script>',
+    '</body>',
+    '</html>'
+  ].join(''))
+  return out
 }

--- a/lib/file-watch.js
+++ b/lib/file-watch.js
@@ -4,7 +4,7 @@ var watch = require('chokidar').watch
 var xtend = require('xtend')
 var Emitter = require('events/')
 
-var ignore = [
+var ignores = [
   'node_modules/**', 'bower_components/**',
   '.git', '.hg', '.svn', '.DS_Store',
   '*.swp', 'thumbs.db', 'desktop.ini'
@@ -12,7 +12,7 @@ var ignore = [
 
 module.exports = function(glob, opt) {
   opt = xtend({
-    ignored: ignore,
+    ignored: ignores,
     ignoreInitial: true
   }, opt)
 
@@ -35,3 +35,5 @@ module.exports = function(glob, opt) {
   }
   return emitter
 }
+
+module.exports.ignores = ignores

--- a/lib/file-watch.js
+++ b/lib/file-watch.js
@@ -12,7 +12,6 @@ var ignore = [
 
 module.exports = function(glob, opt) {
   opt = xtend({
-    event: 'all',
     ignored: ignore,
     ignoreInitial: true
   }, opt)
@@ -20,7 +19,8 @@ module.exports = function(glob, opt) {
   var emitter = new Emitter()
 
   watcher = watch(glob, opt)
-  watcher.on(opt.event, opt.event === 'all' ? reload : reload.bind(null, 'change'))
+  watcher.on('add', reload.bind(null, 'add'))
+  watcher.on('change', reload.bind(null, 'change'))
   
   function reload(event, path) {
     emitter.emit('watch', event, path)

--- a/lib/file-watch.js
+++ b/lib/file-watch.js
@@ -1,0 +1,37 @@
+//Adds file watching capabilities to budo
+var log = require('bole')('budo')
+var watch = require('chokidar').watch
+var xtend = require('xtend')
+var Emitter = require('events/')
+
+var ignore = [
+  'node_modules/**', 'bower_components/**',
+  '.git', '.hg', '.svn', '.DS_Store',
+  '*.swp', 'thumbs.db', 'desktop.ini'
+]
+
+module.exports = function(globs, opt) {
+  opt = xtend({
+    event: 'all',
+    ignored: ignore,
+    ignoreInitial: true
+  }, opt)
+
+  var emitter = new Emitter()
+
+  watcher = watch(glob, opt)
+  watcher.on(opt.event, opt.event === 'all' ? reload : reload.bind(null, 'change'))
+
+  function reload(event, path) {
+    emitter.emit('watch', event, path)
+    log.debug({
+      type: event,
+      url: path
+    })
+  }
+
+  emitter.close = function() {
+    watcher.close()
+  }
+  return emitter
+}

--- a/lib/file-watch.js
+++ b/lib/file-watch.js
@@ -1,4 +1,4 @@
-//Adds file watching capabilities to budo
+//a thin wrapper around chokidar file watching 
 var log = require('bole')('budo')
 var watch = require('chokidar').watch
 var xtend = require('xtend')
@@ -10,7 +10,7 @@ var ignore = [
   '*.swp', 'thumbs.db', 'desktop.ini'
 ]
 
-module.exports = function(globs, opt) {
+module.exports = function(glob, opt) {
   opt = xtend({
     event: 'all',
     ignored: ignore,
@@ -21,7 +21,7 @@ module.exports = function(globs, opt) {
 
   watcher = watch(glob, opt)
   watcher.on(opt.event, opt.event === 'all' ? reload : reload.bind(null, 'change'))
-
+  
   function reload(event, path) {
     emitter.emit('watch', event, path)
     log.debug({

--- a/lib/get-output.js
+++ b/lib/get-output.js
@@ -3,30 +3,30 @@ var tmpdir = require('./tmpdir')
 
 //get an output directory, from user or tmp dir
 module.exports = function getOutput(argv, cb) {
-    var outfile = argv.o || argv.outfile
-    if (!outfile) {
-        //user can specify a mapping for temp dirs
-        var bundleTo = argv.__to || 'bundle.js'
+  var outfile = argv.o || argv.outfile
+  if (!outfile) {
+    //user can specify a mapping for temp dirs
+    var bundleTo = argv.__to || 'bundle.js'
 
-        tmpdir(function(err, filedir) {
-            var output
-            if (!err) {
-                var file = path.join(filedir, bundleTo)
-                output = { 
-                    tmp: true, 
-                    from: file, 
-                    to: bundleTo, 
-                    dir: filedir 
-                }
-            }
-            cb(err, output)
-        })
-    } else {
-        var from = path.join(argv.dir, outfile)
-        cb(null, { 
-            from: from, 
-            to: outfile, 
-            dir: argv.dir
-        })
-    }
+    tmpdir(function(err, filedir) {
+      var output
+      if (!err) {
+        var file = path.join(filedir, bundleTo)
+        output = {
+          tmp: true,
+          from: file,
+          to: bundleTo,
+          dir: filedir
+        }
+      }
+      cb(err, output)
+    })
+  } else {
+    var from = path.join(argv.dir, outfile)
+    cb(null, {
+      from: from,
+      to: outfile,
+      dir: argv.dir
+    })
+  }
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -9,58 +9,71 @@ var html = require('./default-index')
 var inject = require('inject-lr-script')
 
 module.exports.http = function(opts) {
-    var handler = module.exports.static(opts)
-    return http.createServer(handler)
+  var handler = module.exports.static(opts)
+  return http.createServer(handler)
 }
 
 module.exports.static = function(opts) {
-    var basedir = opts.dir || process.cwd()
-    var staticHandler = ecstatic(basedir)
-    var router = Router()
+  var basedir = opts.dir || process.cwd()
+  var staticHandler = ecstatic(basedir)
+  var router = Router()
 
-    var live = opts.live || opts['live-script']
-    var liveOpts = {
-        host: opts.host,
-        port: opts['live-port']
-    }
+  var live = opts.live || opts['live-script']
+  var liveOpts = {
+    host: opts.host,
+    port: opts['live-port']
+  }
 
-    var out = opts.output
-    var entryHandler = staticHandler
-    if (out.tmp) 
-        entryHandler = ecstatic({ root: out.dir })
-
-    router.addRoute('/' + out.to, function(req, res, params) {
-        log.info({ url: req.url, type: 'static' })
-        entryHandler(req, res)
+  var out = opts.output
+  var entryHandler = staticHandler
+  if (out.tmp)
+    entryHandler = ecstatic({
+      root: out.dir
     })
 
-    router.addRoute('/index.html', home)
-    router.addRoute('/', home)
+  router.addRoute('/' + out.to, function(req, res, params) {
+    log.info({
+      url: req.url,
+      type: 'static'
+    })
+    entryHandler(req, res)
+  })
 
-    router.addRoute('*', function(req, res, params) {
-        log.info({ url: req.url, type: 'static' })
+  router.addRoute('/index.html', home)
+  router.addRoute('/', home)
+
+  router.addRoute('*', function(req, res, params) {
+    log.info({
+      url: req.url,
+      type: 'static'
+    })
+    staticHandler(req, res)
+  })
+
+  return router
+
+  function home(req, res, params) {
+    fs.exists(path.join(basedir, 'index.html'), function(exists) {
+      //inject LiveReload into HTML content if needed
+      if (live)
+        res = inject(res, liveOpts)
+      var type = exists ? 'static' : 'generated'
+      log.info({
+        url: req.url,
+        type: type
+      })
+
+      if (exists)
         staticHandler(req, res)
+      else
+        generateIndex(out.to, req, res)
     })
+  }
 
-    return router
-
-    function home(req, res, params) {
-        fs.exists(path.join(basedir, 'index.html'), function(exists) {
-            //inject LiveReload into HTML content if needed
-            if (live) 
-                res = inject(res, liveOpts)
-            var type = exists ? 'static' : 'generated'
-            log.info({ url: req.url, type: type })
-
-            if (exists) 
-                staticHandler(req, res)
-            else 
-                generateIndex(out.to, req, res)
-        })
-    }
-
-    function generateIndex(outfile, req, res) {
-        res.setHeader('content-type', 'text/html')
-        html({ outfile: outfile }).pipe(res)
-    }
+  function generateIndex(outfile, req, res) {
+    res.setHeader('content-type', 'text/html')
+    html({
+      outfile: outfile
+    }).pipe(res)
+  }
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -10,7 +10,18 @@ var inject = require('inject-lr-script')
 
 module.exports.http = function(opts) {
   var handler = module.exports.static(opts)
-  return http.createServer(handler)
+  var server = http.createServer(handler)
+
+  Object.defineProperty(server, '_live', {
+    get: function() {
+      return handler._live
+    },
+    set: function(live) {
+      handler._live = live
+    }
+  })
+
+  return server
 }
 
 module.exports.static = function(opts) {
@@ -18,7 +29,7 @@ module.exports.static = function(opts) {
   var staticHandler = ecstatic(basedir)
   var router = Router()
 
-  var live = opts.live || opts['live-script']
+  router._live = opts.live || opts['live-script']
   var liveOpts = {
     host: opts.host,
     port: opts['live-port']
@@ -26,10 +37,11 @@ module.exports.static = function(opts) {
 
   var out = opts.output
   var entryHandler = staticHandler
-  if (out.tmp)
+  if (out.tmp) {
     entryHandler = ecstatic({
       root: out.dir
     })
+  }
 
   router.addRoute('/' + out.to, function(req, res, params) {
     log.info({
@@ -55,7 +67,7 @@ module.exports.static = function(opts) {
   function home(req, res, params) {
     fs.exists(path.join(basedir, 'index.html'), function(exists) {
       //inject LiveReload into HTML content if needed
-      if (live)
+      if (router._live)
         res = inject(res, liveOpts)
       var type = exists ? 'static' : 'generated'
       log.info({

--- a/lib/server.js
+++ b/lib/server.js
@@ -29,7 +29,7 @@ module.exports.static = function(opts) {
   var staticHandler = ecstatic(basedir)
   var router = Router()
 
-  router._live = opts.live || opts['live-script']
+  router._live = opts.live
   var liveOpts = {
     host: opts.host,
     port: opts['live-port']

--- a/lib/tinylr.js
+++ b/lib/tinylr.js
@@ -1,4 +1,4 @@
-//Adds live-reload capabilities to budo
+//a thin wrapper around tiny-lr module
 var log = require('bole')('budo')
 var xtend = require('xtend')
 var tinylr = require('tiny-lr')
@@ -8,8 +8,7 @@ module.exports = function(glob, opt) {
   opt.host = opt.host || 'localhost'
   if (typeof opt.port !== 'number')
     opt.port = 35729
-
-  var emitter = new Emitter()
+  
   var server = tinylr()
   var closed = false
 
@@ -25,28 +24,28 @@ module.exports = function(glob, opt) {
     if (err.code === 'EADDRINUSE') {
       process.stderr.write('ERROR: livereload not started, port ' + opt.port + ' is in use\n')
       server.close()
+      closed = true
     }
   })
 
-  emitter.close = function() {
-    if (closed)
-      return
-    server.close()
-    closed = true
-  }
+  return {
+    close: function close() {
+      if (closed)
+        return
+      server.close()
+      closed = true
+    },
 
-  emitter.reload = function reload(path) {
-    try {
-      server.changed({
-        body: {
-          files: [path]
-        }
-      })
-      emitter.emit('reload', path)
-    } catch (e) {
-      throw e
+    reload: function reload(path) {
+      try {
+        server.changed({
+          body: {
+            files: [path]
+          }
+        })
+      } catch (e) {
+        throw e
+      }
     }
   }
-
-  return emitter
 }

--- a/lib/tinylr.js
+++ b/lib/tinylr.js
@@ -1,0 +1,52 @@
+//Adds live-reload capabilities to budo
+var log = require('bole')('budo')
+var xtend = require('xtend')
+var tinylr = require('tiny-lr')
+
+module.exports = function(glob, opt) {
+  opt = xtend(opt)
+  opt.host = opt.host || 'localhost'
+  if (typeof opt.port !== 'number')
+    opt.port = 35729
+
+  var emitter = new Emitter()
+  var server = tinylr()
+  var closed = false
+
+  server.listen(opt.port, opt.host, function(a) {
+    if (closed)
+      return
+    log.info('livereload running on ' + opt.port)
+  })
+
+  var serverImpl = server.server
+  serverImpl.removeAllListeners('error')
+  serverImpl.on('error', function(err) {
+    if (err.code === 'EADDRINUSE') {
+      process.stderr.write('ERROR: livereload not started, port ' + opt.port + ' is in use\n')
+      server.close()
+    }
+  })
+
+  emitter.close = function() {
+    if (closed)
+      return
+    server.close()
+    closed = true
+  }
+
+  emitter.reload = function reload(path) {
+    try {
+      server.changed({
+        body: {
+          files: [path]
+        }
+      })
+      emitter.emit('reload', path)
+    } catch (e) {
+      throw e
+    }
+  }
+
+  return emitter
+}

--- a/lib/tmpdir.js
+++ b/lib/tmpdir.js
@@ -5,35 +5,35 @@ var tmp = require('tmp')
 tmp.setGracefulCleanup()
 
 module.exports = function(cb) {
-    tmp.dir({ 
-        mode: '0755', 
-        prefix: 'budo-' 
-    }, 
-      function(err, filepath) {
-        if (!err) {
-            process.on('exit', remove)
-            process.on('SIGINT', exit)
-            process.on('uncaughtException', exit)
-            log.debug('temp directory created at', filepath)
-        }
+  tmp.dir({
+      mode: '0755',
+      prefix: 'budo-'
+    },
+    function(err, filepath) {
+      if (!err) {
+        process.on('exit', remove)
+        process.on('SIGINT', exit)
+        process.on('uncaughtException', exit)
+        log.debug('temp directory created at', filepath)
+      }
 
-        cb(err, filepath)
+      cb(err, filepath)
 
-        function remove(err) {
-            try {
-              rimraf.sync(filepath)
-            } catch(e) {
-              rimraf.sync(filepath)
-            }
-            if (err) 
-                console.error(err.stack)
+      function remove(err) {
+        try {
+          rimraf.sync(filepath)
+        } catch (e) {
+          rimraf.sync(filepath)
         }
-        
-        function exit(err) {
-            if (err)
-                console.error(err.stack)
-            process.exit()
-        }
+        if (err)
+          console.error(err.stack)
+      }
+
+      function exit(err) {
+        if (err)
+          console.error(err.stack)
+        process.exit()
+      }
     })
 
 }

--- a/lib/watchify.js
+++ b/lib/watchify.js
@@ -9,7 +9,12 @@ module.exports = function(watchifyArgs) {
 
   var proc = spawn(cmd)
   proc.stderr.on('data', function(err) {
-    process.stderr.write(err.toString())
+    //nicer messaging for common error cases
+    if (err.toString().indexOf('watchify: command not found') >= 0) {
+      process.stderr.write("ERROR: Could not find watchify\n")
+      process.stderr.write("Make sure to install it locally with --save-dev\n")
+    } else 
+      process.stderr.write(err.toString())
   })
 
   var hasClosed = false

--- a/lib/watchify.js
+++ b/lib/watchify.js
@@ -3,24 +3,24 @@ var quote = require('shell-quote').quote
 
 //Runs watchify with given args, returns process
 module.exports = function(watchifyArgs) {
-    var cmd = ['watchify']
-        .concat(quote(watchifyArgs||[]))
-        .join(' ')
+  var cmd = ['watchify']
+    .concat(quote(watchifyArgs || []))
+    .join(' ')
 
-    var proc = spawn(cmd)
-    proc.stderr.on('data', function(err) {
-        process.stderr.write(err.toString())
-    })
+  var proc = spawn(cmd)
+  proc.stderr.on('data', function(err) {
+    process.stderr.write(err.toString())
+  })
 
-    var hasClosed = false
-    process.on('close', handleClose)
-    process.on('exit', handleClose)
-    
-    return proc
+  var hasClosed = false
+  process.on('close', handleClose)
+  process.on('exit', handleClose)
 
-    function handleClose() {
-        if (hasClosed) return
-        hasClosed = true
-        proc.kill()   
-    }
+  return proc
+
+  function handleClose() {
+    if (hasClosed) return
+    hasClosed = true
+    proc.kill()
+  }
 }

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
   "scripts": {
     "test": "tape test/test*.js | tap-spec",
     "start": "./bin/cmd.js example/app.js --dir example --verbose | garnish",
-    "live": "./bin/cmd.js example/app.js --dir example --live | garnish -v",
-    "live-plugin": "./bin/cmd.js example/app.js --dir example --live-plugin | garnish -v",
-    "remap": "./bin/cmd.js example/app:bundle2.js --dir example --live | garnish -v"
+    "live": "./bin/cmd.js example/app.js --dir example --live | garnish",
+    "live-plugin": "./bin/cmd.js example/app.js --dir example --live-plugin | garnish",
+    "remap": "./bin/cmd.js example/app:bundle2.js --dir example --live | garnish"
   },
   "keywords": [
     "browserify",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dargs": "^4.0.0",
     "ecstatic": "^0.5.8",
     "events": "^1.0.2",
+    "getport": "^0.1.0",
     "inject-lr-script": "^1.0.0",
     "minimist": "^1.1.0",
     "npm-execspawn": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "bole": "^2.0.0",
+    "chokidar": "^1.0.0-rc4",
     "dargs": "^4.0.0",
     "ecstatic": "^0.5.8",
     "events": "^1.0.2",
@@ -26,6 +27,7 @@
     "routes-router": "^4.1.2",
     "shell-quote": "^1.4.3",
     "through2": "^0.6.3",
+    "tiny-lr": "^0.1.5",
     "tmp": "0.0.24",
     "wtch": "^3.2.1",
     "xtend": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "tape": "^3.5.0",
     "through2": "^0.6.3",
     "tree-kill": "0.0.6",
-    "watchify": "^2.6.2",
+    "watchify": "^3.0.0",
     "win-spawn": "^2.0.0"
   },
   "scripts": {

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -5,6 +5,7 @@ var path = require('path')
 
 test('sets watch() after connect', function(t) {
   t.plan(9)
+  t.timeoutAfter(10000)
 
   budo('test/app.js', {
     dir: __dirname,
@@ -42,6 +43,7 @@ test('sets watch() after connect', function(t) {
 
 test('sets watch() with args before connect', function(t) {
   t.plan(3)
+  t.timeoutAfter(10000)
 
   var app = budo('test/app.js', {
     dir: __dirname,
@@ -71,6 +73,7 @@ test('sets watch() with args before connect', function(t) {
 
 test('sets watch() and live() by default with live: true', function(t) {
   t.plan(4)
+  t.timeoutAfter(10000)
 
   var app = budo('test/app.js', {
     dir: __dirname,

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -14,19 +14,22 @@ test('should provide an API', function(t) {
   .on('error', function(err) {
     t.fail(err)
   })
-  .on('connect', function(ev) {
+  .on('connect', function(app) {
     var file = path.join(__dirname, 'bundle.js')
-    t.equal(ev.to, 'bundle.js', 'mapping matches')
-    t.equal(ev.from, file, 'from matches')
-    t.equal(ev.uri, 'http://localhost:8000/', 'uri matches')
-    t.equal(ev.host, 'localhost', 'host is not specified')
-    t.equal(ev.port, 8000, 'port matches')
-    t.equal(ev.glob, file, 'glob matches file')
-    t.equal(ev.dir, __dirname, 'dir matches')
-    setTimeout(function() {
-      ev.close()
-      cleanup()
-    }, 1000)
+    t.equal(app.to, 'bundle.js', 'mapping matches')
+    t.equal(app.from, file, 'from matches')
+    t.equal(app.uri, 'http://localhost:8000/', 'uri matches')
+    t.equal(app.host, 'localhost', 'host is not specified')
+    t.equal(app.port, 8000, 'port matches')
+    t.equal(app.glob, file, 'glob matches file')
+    t.equal(app.dir, __dirname, 'dir matches')
+
+    app
+      .watch(app.glob)
+      .once('watch', function(type) {
+        app.close()
+        cleanup()
+      })
   })
   .on('exit', function() {
     t.ok(true, 'closing')

--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -12,15 +12,12 @@ var request = require('request')
 
 var cliPath = path.resolve(__dirname, '..', 'bin', 'cmd.js')
 
-// Some other tests needed:
-// --live
-// --live-plugin
-
 test('should fail without scripts', function(t) {
   t.plan(1)
   var proc = spawn(cliPath)
   proc.stderr.pipe(concat(function(str) {
-    t.equal(str.toString().trim(), 'No entry scripts specified!')
+    var msg = str.toString().toLowerCase()
+    t.notEqual(msg.indexOf('no entry scripts specified'), -1)
   }))
 })
 

--- a/test/test-live.js
+++ b/test/test-live.js
@@ -42,6 +42,47 @@ test('should inject LiveReload snippet', function(t) {
   })
 })
 
+
+test('manual LiveReload triggering', function(t) {
+  t.plan(4)
+  t.timeoutAfter(10000)
+
+  var server
+
+  var entry = path.join(__dirname, 'app.js')
+  var app = budo(entry, {
+    dir: __dirname,
+    port: 8000,
+    outfile: 'bundle.js',
+    live: false,
+    'live-script': true
+  })
+  .watch()
+  .live()
+  .on('error', function(err) {
+    t.fail(err)
+  })
+  .on('watch', function(event, file) {
+    t.equal(path.basename(file), 'bundle.js', 'watch event triggered')
+    app.reload(file)
+  })
+  .on('reload', function(file) {
+    t.equal(path.basename(file), 'bundle.js', 'reload event triggered')
+    cleanup()
+    server.close()
+  })
+  .on('connect', function(ev) {
+    server = ev
+    matchesHTML(t, ev.uri)
+    setTimeout(function() {
+      fs.writeFile(entry, source)
+    }, 1000)
+  })
+  .on('exit', function() {
+    t.ok(true, 'closing')
+  })
+})
+
 function matchesHTML(t, uri) {
   request.get({ uri: uri + 'index.html' }, function(err, resp, body) {
     if (err) t.fail(err)


### PR DESCRIPTION
WIP 

- moving to 2 spaces for whitespacing
- removing `wtch` since it was leading to more complexity than it's worth
- decoupling watch from LiveReload since you often may only need one
- adding `live()` and `watch()` methods
- cleaning up the budo API so that there is just one emitter (the budo instance) rather than two
- supporting `--poll` and `--ignore-watch` options in watchify@3 and sending them to file-watch for live reload
- adding help messages
- improving error messages when watchify is not found or when no entries are given