### PR TITLE
Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ PRs/suggestions/comments welcome. Props to [@caspervonb](https://twitter.com/cas
 
 - [basic usage](docs/basics.md)
 - [comparisons](docs/comparisons.md)
+- [programmatic usage (Gulp, Grunt)](docs/programmatic-usage.md)
 - [error reporting](docs/errors.md)
 - [running tests and examples](docs/tests-and-examples.md)
 - [script injection with budo-chrome](https://github.com/mattdesl/budo-chrome)
-- [programmatic usage (Gulp, Grunt)](docs/programmatic-usage.md)
 - [rapid prototyping with budō and wzrd](http://mattdesl.svbtle.com/rapid-prototyping)
 
 ## usage
@@ -58,12 +58,13 @@ Usage:
     budo [entries] [opts]
 
 Options:
+    --help, -h      show help message
     --outfile, -o   path to output bundle
     --port          the port to run, default 9966
     --host          the host, default "localhost"
     --dir           the directory to serve, and the base for --outfile
-    --live          enable LiveReload integration
-    --live-plugin   enable LiveReload but do not inject script tag
+    --live          enable LiveReload integration with a script tag
+    --live-plugin   enable LiveReload for use with a browser plugin
     --live-port     the LiveReload port, default 35729
 ```
 

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,18 +1,35 @@
 #!/usr/bin/env node
 
-//Starts up budo with some logging,
-//also listens for live reload events
+//Starts budo with stdout
+//Handles --help and error messaging
+//Uses auto port-finding
 
 var args = process.argv.slice(2)
 var opts = require('minimist')(args)
-var portfinder = require('portfinder')
+var getport = require('getport')
 
 var entries = opts._
 opts.stream = process.stdout
 delete opts._
 
-portfinder.basePort = opts.port || opts.p || 9966
-portfinder.getPort(function(err, port) {
+var showHelp = opts.h || opts.help
+
+if (!showHelp && (!entries || entries.filter(Boolean).length === 0)) {
+    console.error('ERROR: no entry scripts specified\n  use --help for examples')
+    return
+}
+
+if (showHelp) {
+    var vers = require('../package.json').version
+    console.log('budo '+vers, '\n')
+    var help = require('path').join(__dirname, 'help.txt')
+    require('fs').createReadStream(help)
+        .pipe(process.stdout)
+    return
+}
+
+var basePort = opts.port || opts.p || 9966
+getport(basePort, function(err, port) {
     if (err) {
         console.error("Could not find port", err)
         process.exit(1)

--- a/bin/help.txt
+++ b/bin/help.txt
@@ -1,0 +1,17 @@
+Usage:
+  budo index.js [opts] [browserify opts]
+
+Options:
+    --help, -h      show help message
+    --outfile, -o   path to output bundle
+    --port          the port to run, default 9966
+    --host          the host, default "localhost"
+    --dir           the directory to serve, and the base for --outfile
+    --live          enable LiveReload integration
+    --live-plugin   enable LiveReload but do not inject script tag
+    --live-port     the LiveReload port, default 35729
+
+Examples:
+  budo index.js --live --dir app/ --outfile bundle.js
+  budo index.js --verbose --transform brfs
+  budo index.js:test.js --port 3000

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -26,7 +26,7 @@ wzrd index.js:bundle.js | garnish
 
 ## wtch
 
-[wtch](https://github.com/mattdesl/wtch) is a small live-reload utility that budō builds on. It watches for JS/CSS/HTML changes and triggers a live-reload event. It can be used to augment wzrd with some watching capabilities.
+[wtch](https://github.com/mattdesl/wtch) is a small live-reload utility not related to budo or watchify. It watches for JS/CSS/HTML changes and triggers a live-reload event. It can be used to augment wzrd with some watching capabilities.
 
 ```sh
 #example ...

--- a/example/app.js
+++ b/example/app.js
@@ -14,15 +14,15 @@ img.src = 'baboon.png'
 var time = 0
 
 require('raf-loop')(function(dt) {
-    var width = window.innerWidth,
-        height = window.innerHeight
+    var width = ctx.canvas.width,
+        height = ctx.canvas.height
     ctx.clearRect(0, 0, width, height)
 
     time += dt/1000
 
     ctx.save()
     ctx.scale(dpr, dpr)
-    ctx.fillRect(Math.sin(time)*50 + 200, 35, 150, 150) 
+    ctx.fillRect(Math.sin(time)*50 + 300, 200, 150, 50) 
     ctx.fillText("from browserify!", 40, 40)
     if (img.width > 0 || img.height > 0)
         ctx.drawImage(img, 50, 50)

--- a/example/theme.css
+++ b/example/theme.css
@@ -1,3 +1,3 @@
 body {
-    background: #eee;
+    background: #efefef;
 }

--- a/index.js
+++ b/index.js
@@ -4,87 +4,86 @@ var xtend = require('xtend')
 var assign = require('xtend/mutable')
 var Emitter = require('events/')
 var getOutput = require('./lib/get-output')
-var wtch = require('wtch')
-
-var defaultGlob = '**/*.{html,css}'
 
 var budo = require('./lib/budo')
 
 module.exports = function(entry, opts) {
-    var argv = assign({}, opts)
+  var argv = assign({}, opts)
 
-    if (argv.stream) {
-        bole.output({
-            stream: argv.stream,
-            level: 'debug'
-        })
-    }
-
-    var emitter = new Emitter()
-    var watcher
-
-    var entries = Array.isArray(entry) ? entry : [ entry ]
-    entries = entries.filter(Boolean)
-    if (entries.length === 0) {
-        bail("No entry scripts specified!")
-        return emitter
-    }
-
-    argv.port = typeof argv.port === 'number' ? argv.port : 9966
-    argv.dir = argv.dir || process.cwd()
-    var outOpts = xtend(argv, { __to: entryMapping() })
-
-    getOutput(outOpts, function(err, output) {
-        if (err) {
-            bail("Error: Could not create temp bundle.js directory")
-            return emitter
-        }
-
-        //run watchify server
-        var app = budo(entries, output, argv)
-            .on('error', function(err2) {
-                var msg = "Error running budo on " + argv.port + ': ' + err2
-                bail(msg)
-            })
-            .on('exit', function() {
-                log.info('closing')
-                emitter.emit('exit')
-                if (watcher)
-                    watcher.close()
-            })
-            .on('connect', function() {
-                //setup live reload
-                if (argv.live || argv['live-plugin']) {
-                    var liveOptions = { 
-                        port: argv['live-port']
-                    }
-                    
-                    //dispatches watch and LiveReload events
-                    watcher = wtch([defaultGlob, app.glob], liveOptions)
-                    watcher.on('watch', emitter.emit.bind(emitter, 'watch'))
-                    watcher.on('reload', emitter.emit.bind(emitter, 'reload'))
-                }
-                emitter.emit('connect', app)
-            })
+  if (argv.stream) {
+    bole.output({
+      stream: argv.stream,
+      level: 'debug'
     })
+  }
+  
+  var emitter = budo()
+  emitter.on('connect', setupLive)
 
+  var entries = Array.isArray(entry) ? entry : [entry]
+  entries = entries.filter(Boolean)
+  if (entries.length === 0) {
+    bail("No entry scripts specified!")
     return emitter
+  }
 
-    function entryMapping() {
-        var to
-        var first = entries[0]
-        var parts = first.split(':')
-        if (parts.length > 1 && parts[1].length > 0) {
-            var from = parts[0]
-            to = parts[1]
-            entries[0] = from
-        }
-        return to
+  argv.port = typeof argv.port === 'number' ? argv.port : 9966
+  argv.dir = argv.dir || process.cwd()
+  var outOpts = xtend(argv, {
+    __to: entryMapping()
+  })
+
+  getOutput(outOpts, function(err, output) {
+    if (err) {
+      bail("Error: Could not create temp bundle.js directory")
+      return emitter
     }
 
-    function bail(msg) {
-        process.nextTick(function() {
-            emitter.emit('error', new Error(msg))
+    //run watchify server
+    emitter._start(entries, output, argv)
+      .on('error', function(err2) {
+        var msg = "Error running budo on " + argv.port + ': ' + err2
+        bail(msg)
+      })
+      .on('exit', function() {
+        log.info('closing')
+      })
+  })
+
+  return emitter
+
+  //if user requested live: true, set it up with some defaults
+  function setupLive() {
+    if (argv.live || argv['live-plugin']) {
+      emitter
+        .watch()
+        .live({ 
+          host: argv.host,
+          port: argv['live-port']
+        })
+        .on('watch', function(ev, file) {
+          if (ev === 'change' || ev === 'add') {
+            emitter.reload(file)
+          }
         })
     }
+  }
+
+  function entryMapping() {
+    var to
+    var first = entries[0]
+    var parts = first.split(':')
+    if (parts.length > 1 && parts[1].length > 0) {
+      var from = parts[0]
+      to = parts[1]
+      entries[0] = from
+    }
+    return to
+  }
+
+  function bail(msg) {
+    process.nextTick(function() {
+      emitter.emit('error', new Error(msg))
+    })
+  }
 }

--- a/lib/budo.js
+++ b/lib/budo.js
@@ -6,94 +6,213 @@ var assign = require('xtend/mutable')
 var http = require('./server').http
 var log = require('bole')('budo')
 var dargs = require('dargs')
+var createFileWatch = require('./file-watch')
+var createTinylr = require('./tinylr')
 
-module.exports = function(entries, output, opt) {
-    opt = opt||{}
+module.exports = function() {
+  var emitter = new Emitter()
+  var started = false
+  var closed = false
 
-    var port = opt.port || 9966
-    var host = opt.host
-    var serverOpt = xtend(opt, { output: output })
-    
-    var emitter = new Emitter()
-    var closed = false
+  var watchifyProc
+  var server
+  var watcher
+  var tinylr
+  var defaultGlobs
+  var defaultLiveOpts
+  var defaultWatchOpts
+  var deferreds = []
 
-    //spin up watchify instance
-    var watchifyArgs = getWatchifyArgs(entries, output, opt)
-    var watchProc = watchify(watchifyArgs)
-    
-    var server = http(serverOpt)
-        .on('error', function(err) {
-            emitter.emit('error', err)
-        })
-        .listen(port, host, handler)
-        
-    emitter.close = function() {
-        if (closed) return
-        closed = true
-        watchProc.kill()
-        server.close()
-        emitter.emit('exit')
-    }
-
-    //when watchify ends, close the server
-    watchProc.stderr.on('end', function() {
-        emitter.close()
+  emitter._start = function(entries, output, opt) {
+    opt = opt || {}
+    var port = opt.port
+    var serverOpt = xtend(opt, {
+      output: output
     })
-    return emitter
 
-    function handler(err) {
+    server = http(serverOpt)
+      .on('error', function(err) {
+        emitter.emit('error', err)
+      })
+      .listen(port, opt.host, function(err) {
         if (err) {
-            emitter.emit('error', new Error("Could not connect to server: " + err))
-            return 
+          emitter.emit('error', new Error("Could not connect to server: " + err))
+          return
         }
-        var hostname = (host||'localhost')
-        var uri = "http://"+hostname+":"+port+"/"
-        log.info("Server running at", uri)
 
-        //bug with chokidar@1.0.0-rc3
-        //anything in OSX tmp dirs need a wildcard
-        //to work with fsevents
-        var glob = output.tmp 
-            ? path.join(output.dir, '**.js')
-            : output.from
+        //setup "event" param for callback
+        assignOptions(output, opt)
 
-        //add the uri / output to budo instance
-        assign(emitter, {
-            uri: uri,
-            port: port,
-            host: hostname,
-            server: server
-        }, output, { glob: glob })
+        //start watchify process
+        runWatchify(entries, output, opt)
+        
+        started = true
+        
+        //if user wanted live() or watch() enabled
+        deferreds.forEach(function(func) {
+          func()
+        })
+        deferreds.length = 0
+
+        //finally, emit callback
         emitter.emit('connect', emitter)
+      })
+    return emitter
+  }
+  
+  //no-op until live() is enabled
+  emitter.reload = noop
+
+  //enable file watch capabilities
+  emitter.watch = function(glob, watchOpt) {
+    if (!started) {
+      deferreds.push(emitter.watch.bind(null, glob, watchOpt))
     }
+    else {
+      watchOpt = xtend(defaultWatchOpts, watchOpt)
+      watchOpt = getChokidarOpts(watchOpt) //transform to chokidar
+      watcher = createFileWatch(glob || defaultGlobs, watchOpt)
+      watcher.on('watch', emitter.emit.bind(emitter, 'watch'))
+      emitter.watch = noop
+    }
+    return emitter
+  }
+
+  //enable live-reload capabilities
+  emitter.live = function(liveOpt) {
+    if (!started) {
+      deferreds.push(emitter.live.bind(null, liveOpt))
+    } else {
+      liveOpt = liveOpt||{}
+      server._live = !liveOpt.plugin
+      tinylr = createTinylr(xtend(defaultLiveOpts, liveOpt))
+      emitter.reload = function(path) {
+        tinylr.reload(path)
+        emitter.emit('reload', path)
+      }
+      emitter.live = noop
+    }
+    return emitter
+  }
+
+  //close everything
+  emitter.close = function() {
+    if (closed)
+      return
+    closed = true
+    if (watchifyProc)
+      watchifyProc.kill()
+    if (watcher)
+      watcher.close()
+    if (tinylr)
+      tinylr.close()
+    if (server)
+      server.close()
+    emitter.live = noop
+    emitter.watch = noop
+    emitter.emit('exit')
+  }
+
+  return emitter
+
+  function runWatchify(entries, output, opt) {    
+    if (closed)
+      return
+
+    //setup watchify; when it ends, close the server
+    var watchifyArgs = getWatchifyArgs(entries, output, opt)
+    watchifyProc = watchify(watchifyArgs)
+    watchifyProc.stderr.on('end', function() {
+      emitter.close()
+    })
+  }
+
+  function assignOptions(output, opt) {
+    var hostname = (opt.host || 'localhost')
+    var uri = "http://" + hostname + ":" + opt.port + "/"
+    log.info("Server running at", uri)
+
+    //bug with chokidar@1.0.0-rc3
+    //anything in OSX tmp dirs need a wildcard
+    //to work with fsevents
+    var glob = output.tmp ? path.join(output.dir, '*.js') : output.from
+
+    //add the uri / output to budo instance
+    assign(emitter, {
+      uri: uri,
+      port: opt.port,
+      host: hostname,
+      server: server,
+      'live-port': opt['live-port']
+    }, output, {
+      glob: glob
+    })
+
+    //defaults for live() / watch() functions
+    defaultGlobs = ['**/*.{html,css}', emitter.glob]
+    //watchify@3 has some extra options
+    defaultWatchOpts = {
+      poll: opt.poll,
+      'ignore-watch': typeof opt['ignore-watch'] === 'undefined' ? opt.iw : opt['ignore-watch']
+    }
+    defaultLiveOpts = {
+      plugin: opt['live-plugin'],
+      host: opt.host,
+      port: emitter['live-port']
+    }
+  }
+
+  function noop() {
+    return emitter
+  }
+}
+
+function getChokidarOpts(opt) {
+  //do not mutate original opts
+  opt = assign({}, opt)
+
+  if (opt.poll || opt.poll === 0) {
+    var interval = opt.poll
+    opt.usePolling = true
+    opt.interval = typeof interval === 'number' ? interval : 100
+    delete opt.poll
+  }
+  if (opt['ignore-watch'] || typeof opt['ignore-watch'] === 'string') {
+    opt.ignored = opt['ignore-watch']
+    delete opt['ignore-watch']
+  } else {
+    //otherwise let file-watch ignore some defaults
+    delete opt.ignored
+  }
+  return opt
 }
 
 function getWatchifyArgs(entries, output, opt) {
-    //do not mutate original opts
-    opt = assign({}, opt)
+  //do not mutate original opts
+  opt = assign({}, opt)
 
-    //set output file
-    opt.outfile = output.from
-    delete opt.o
+  //set output file
+  opt.outfile = output.from
+  delete opt.o
 
-    //enable debug by default
-    if (opt.d !== false && opt.debug !== false) {
-        delete opt.d
-        opt.debug = true
-    } 
-    //if user explicitly disabled debug...
-    else if (opt.d === false || opt.debug === false) {
-        delete opt.d
-        delete opt.debug
-    }
+  //enable debug by default
+  if (opt.d !== false && opt.debug !== false) {
+    delete opt.d
+    opt.debug = true
+  }
+  //if user explicitly disabled debug...
+  else if (opt.d === false || opt.debug === false) {
+    delete opt.d
+    delete opt.debug
+  }
 
-    //clean up some possible collisions
-    delete opt.dir
-    delete opt.port
-    delete opt.host
-    delete opt.live
-    delete opt['live-port']
-    delete opt['live-script']
-    delete opt['live-plugin']
-    return entries.concat(dargs(opt))
+  //clean up some possible collisions
+  delete opt.dir
+  delete opt.port
+  delete opt.host
+  delete opt.live
+  delete opt['live-port']
+  delete opt['live-script']
+  delete opt['live-plugin']
+  return entries.concat(dargs(opt))
 }

--- a/lib/default-index.js
+++ b/lib/default-index.js
@@ -1,14 +1,14 @@
 var through2 = require('through2')
 
 module.exports = function(opt) {
-    var out = through2()
-    out.end([
-        '<!doctype html>',
-        '<head><meta charset="utf-8">',
-        '</head><body>',
-        '<script src="' + opt.outfile + '"></script>',
-        '</body>',
-        '</html>'
-    ].join(''))
-    return out
+  var out = through2()
+  out.end([
+    '<!doctype html>',
+    '<head><meta charset="utf-8">',
+    '</head><body>',
+    '<script src="' + opt.outfile + '"></script>',
+    '</body>',
+    '</html>'
+  ].join(''))
+  return out
 }

--- a/lib/file-watch.js
+++ b/lib/file-watch.js
@@ -1,0 +1,39 @@
+//a thin wrapper around chokidar file watching 
+var log = require('bole')('budo')
+var watch = require('chokidar').watch
+var xtend = require('xtend')
+var Emitter = require('events/')
+
+var ignores = [
+  'node_modules/**', 'bower_components/**',
+  '.git', '.hg', '.svn', '.DS_Store',
+  '*.swp', 'thumbs.db', 'desktop.ini'
+]
+
+module.exports = function(glob, opt) {
+  opt = xtend({
+    ignored: ignores,
+    ignoreInitial: true
+  }, opt)
+
+  var emitter = new Emitter()
+
+  watcher = watch(glob, opt)
+  watcher.on('add', reload.bind(null, 'add'))
+  watcher.on('change', reload.bind(null, 'change'))
+  
+  function reload(event, path) {
+    emitter.emit('watch', event, path)
+    log.debug({
+      type: event,
+      url: path
+    })
+  }
+
+  emitter.close = function() {
+    watcher.close()
+  }
+  return emitter
+}
+
+module.exports.ignores = ignores

--- a/lib/get-output.js
+++ b/lib/get-output.js
@@ -3,30 +3,30 @@ var tmpdir = require('./tmpdir')
 
 //get an output directory, from user or tmp dir
 module.exports = function getOutput(argv, cb) {
-    var outfile = argv.o || argv.outfile
-    if (!outfile) {
-        //user can specify a mapping for temp dirs
-        var bundleTo = argv.__to || 'bundle.js'
+  var outfile = argv.o || argv.outfile
+  if (!outfile) {
+    //user can specify a mapping for temp dirs
+    var bundleTo = argv.__to || 'bundle.js'
 
-        tmpdir(function(err, filedir) {
-            var output
-            if (!err) {
-                var file = path.join(filedir, bundleTo)
-                output = { 
-                    tmp: true, 
-                    from: file, 
-                    to: bundleTo, 
-                    dir: filedir 
-                }
-            }
-            cb(err, output)
-        })
-    } else {
-        var from = path.join(argv.dir, outfile)
-        cb(null, { 
-            from: from, 
-            to: outfile, 
-            dir: argv.dir
-        })
-    }
+    tmpdir(function(err, filedir) {
+      var output
+      if (!err) {
+        var file = path.join(filedir, bundleTo)
+        output = {
+          tmp: true,
+          from: file,
+          to: bundleTo,
+          dir: filedir
+        }
+      }
+      cb(err, output)
+    })
+  } else {
+    var from = path.join(argv.dir, outfile)
+    cb(null, {
+      from: from,
+      to: outfile,
+      dir: argv.dir
+    })
+  }
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -9,58 +9,83 @@ var html = require('./default-index')
 var inject = require('inject-lr-script')
 
 module.exports.http = function(opts) {
-    var handler = module.exports.static(opts)
-    return http.createServer(handler)
+  var handler = module.exports.static(opts)
+  var server = http.createServer(handler)
+
+  Object.defineProperty(server, '_live', {
+    get: function() {
+      return handler._live
+    },
+    set: function(live) {
+      handler._live = live
+    }
+  })
+
+  return server
 }
 
 module.exports.static = function(opts) {
-    var basedir = opts.dir || process.cwd()
-    var staticHandler = ecstatic(basedir)
-    var router = Router()
+  var basedir = opts.dir || process.cwd()
+  var staticHandler = ecstatic(basedir)
+  var router = Router()
 
-    var live = opts.live || opts['live-script']
-    var liveOpts = {
-        host: opts.host,
-        port: opts['live-port']
-    }
+  router._live = opts.live
+  var liveOpts = {
+    host: opts.host,
+    port: opts['live-port']
+  }
 
-    var out = opts.output
-    var entryHandler = staticHandler
-    if (out.tmp) 
-        entryHandler = ecstatic({ root: out.dir })
-
-    router.addRoute('/' + out.to, function(req, res, params) {
-        log.info({ url: req.url, type: 'static' })
-        entryHandler(req, res)
+  var out = opts.output
+  var entryHandler = staticHandler
+  if (out.tmp) {
+    entryHandler = ecstatic({
+      root: out.dir
     })
+  }
 
-    router.addRoute('/index.html', home)
-    router.addRoute('/', home)
+  router.addRoute('/' + out.to, function(req, res, params) {
+    log.info({
+      url: req.url,
+      type: 'static'
+    })
+    entryHandler(req, res)
+  })
 
-    router.addRoute('*', function(req, res, params) {
-        log.info({ url: req.url, type: 'static' })
+  router.addRoute('/index.html', home)
+  router.addRoute('/', home)
+
+  router.addRoute('*', function(req, res, params) {
+    log.info({
+      url: req.url,
+      type: 'static'
+    })
+    staticHandler(req, res)
+  })
+
+  return router
+
+  function home(req, res, params) {
+    fs.exists(path.join(basedir, 'index.html'), function(exists) {
+      //inject LiveReload into HTML content if needed
+      if (router._live)
+        res = inject(res, liveOpts)
+      var type = exists ? 'static' : 'generated'
+      log.info({
+        url: req.url,
+        type: type
+      })
+
+      if (exists)
         staticHandler(req, res)
+      else
+        generateIndex(out.to, req, res)
     })
+  }
 
-    return router
-
-    function home(req, res, params) {
-        fs.exists(path.join(basedir, 'index.html'), function(exists) {
-            //inject LiveReload into HTML content if needed
-            if (live) 
-                res = inject(res, liveOpts)
-            var type = exists ? 'static' : 'generated'
-            log.info({ url: req.url, type: type })
-
-            if (exists) 
-                staticHandler(req, res)
-            else 
-                generateIndex(out.to, req, res)
-        })
-    }
-
-    function generateIndex(outfile, req, res) {
-        res.setHeader('content-type', 'text/html')
-        html({ outfile: outfile }).pipe(res)
-    }
+  function generateIndex(outfile, req, res) {
+    res.setHeader('content-type', 'text/html')
+    html({
+      outfile: outfile
+    }).pipe(res)
+  }
 }

--- a/lib/tinylr.js
+++ b/lib/tinylr.js
@@ -1,0 +1,51 @@
+//a thin wrapper around tiny-lr module
+var log = require('bole')('budo')
+var xtend = require('xtend')
+var tinylr = require('tiny-lr')
+
+module.exports = function(glob, opt) {
+  opt = xtend(opt)
+  opt.host = opt.host || 'localhost'
+  if (typeof opt.port !== 'number')
+    opt.port = 35729
+  
+  var server = tinylr()
+  var closed = false
+
+  server.listen(opt.port, opt.host, function(a) {
+    if (closed)
+      return
+    log.info('livereload running on ' + opt.port)
+  })
+
+  var serverImpl = server.server
+  serverImpl.removeAllListeners('error')
+  serverImpl.on('error', function(err) {
+    if (err.code === 'EADDRINUSE') {
+      process.stderr.write('ERROR: livereload not started, port ' + opt.port + ' is in use\n')
+      server.close()
+      closed = true
+    }
+  })
+
+  return {
+    close: function close() {
+      if (closed)
+        return
+      server.close()
+      closed = true
+    },
+
+    reload: function reload(path) {
+      try {
+        server.changed({
+          body: {
+            files: [path]
+          }
+        })
+      } catch (e) {
+        throw e
+      }
+    }
+  }
+}

--- a/lib/tmpdir.js
+++ b/lib/tmpdir.js
@@ -5,35 +5,35 @@ var tmp = require('tmp')
 tmp.setGracefulCleanup()
 
 module.exports = function(cb) {
-    tmp.dir({ 
-        mode: '0755', 
-        prefix: 'budo-' 
-    }, 
-      function(err, filepath) {
-        if (!err) {
-            process.on('exit', remove)
-            process.on('SIGINT', exit)
-            process.on('uncaughtException', exit)
-            log.debug('temp directory created at', filepath)
-        }
+  tmp.dir({
+      mode: '0755',
+      prefix: 'budo-'
+    },
+    function(err, filepath) {
+      if (!err) {
+        process.on('exit', remove)
+        process.on('SIGINT', exit)
+        process.on('uncaughtException', exit)
+        log.debug('temp directory created at', filepath)
+      }
 
-        cb(err, filepath)
+      cb(err, filepath)
 
-        function remove(err) {
-            try {
-              rimraf.sync(filepath)
-            } catch(e) {
-              rimraf.sync(filepath)
-            }
-            if (err) 
-                console.error(err.stack)
+      function remove(err) {
+        try {
+          rimraf.sync(filepath)
+        } catch (e) {
+          rimraf.sync(filepath)
         }
-        
-        function exit(err) {
-            if (err)
-                console.error(err.stack)
-            process.exit()
-        }
+        if (err)
+          console.error(err.stack)
+      }
+
+      function exit(err) {
+        if (err)
+          console.error(err.stack)
+        process.exit()
+      }
     })
 
 }

--- a/lib/watchify.js
+++ b/lib/watchify.js
@@ -3,24 +3,29 @@ var quote = require('shell-quote').quote
 
 //Runs watchify with given args, returns process
 module.exports = function(watchifyArgs) {
-    var cmd = ['watchify']
-        .concat(quote(watchifyArgs||[]))
-        .join(' ')
+  var cmd = ['watchify']
+    .concat(quote(watchifyArgs || []))
+    .join(' ')
 
-    var proc = spawn(cmd)
-    proc.stderr.on('data', function(err) {
-        process.stderr.write(err.toString())
-    })
+  var proc = spawn(cmd)
+  proc.stderr.on('data', function(err) {
+    //nicer messaging for common error cases
+    if (err.toString().indexOf('watchify: command not found') >= 0) {
+      process.stderr.write("ERROR: Could not find watchify\n")
+      process.stderr.write("Make sure to install it locally with --save-dev\n")
+    } else 
+      process.stderr.write(err.toString())
+  })
 
-    var hasClosed = false
-    process.on('close', handleClose)
-    process.on('exit', handleClose)
-    
-    return proc
+  var hasClosed = false
+  process.on('close', handleClose)
+  process.on('exit', handleClose)
 
-    function handleClose() {
-        if (hasClosed) return
-        hasClosed = true
-        proc.kill()   
-    }
+  return proc
+
+  function handleClose() {
+    if (hasClosed) return
+    hasClosed = true
+    proc.kill()
+  }
 }

--- a/package.json
+++ b/package.json
@@ -14,20 +14,21 @@
   },
   "dependencies": {
     "bole": "^2.0.0",
+    "chokidar": "^1.0.0-rc5",
     "dargs": "^4.0.0",
     "ecstatic": "^0.5.8",
     "events": "^1.0.2",
+    "getport": "^0.1.0",
     "inject-lr-script": "^1.0.0",
     "minimist": "^1.1.0",
     "npm-execspawn": "^1.0.6",
-    "portfinder": "^0.4.0",
     "response-stream": "0.0.0",
     "rimraf": "^2.2.8",
     "routes-router": "^4.1.2",
     "shell-quote": "^1.4.3",
     "through2": "^0.6.3",
+    "tiny-lr": "^0.1.5",
     "tmp": "0.0.24",
-    "wtch": "^3.2.1",
     "xtend": "^4.0.0"
   },
   "devDependencies": {
@@ -47,15 +48,15 @@
     "tape": "^3.5.0",
     "through2": "^0.6.3",
     "tree-kill": "0.0.6",
-    "watchify": "^2.6.2",
+    "watchify": "^3.0.0",
     "win-spawn": "^2.0.0"
   },
   "scripts": {
     "test": "tape test/test*.js | tap-spec",
     "start": "./bin/cmd.js example/app.js --dir example --verbose | garnish",
-    "live": "./bin/cmd.js example/app.js --dir example --live | garnish -v",
-    "live-plugin": "./bin/cmd.js example/app.js --dir example --live-plugin | garnish -v",
-    "remap": "./bin/cmd.js example/app:bundle2.js --dir example --live | garnish -v"
+    "live": "./bin/cmd.js example/app.js --dir example --live | garnish",
+    "live-plugin": "./bin/cmd.js example/app.js --dir example --live-plugin | garnish",
+    "remap": "./bin/cmd.js example/app:bundle2.js --dir example --live | garnish"
   },
   "keywords": [
     "browserify",

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -3,8 +3,9 @@ var budo = require('../')
 var cleanup = require('./cleanup')
 var path = require('path')
 
-test('should provide an API', function(t) {
-  t.plan(8)
+test('sets watch() after connect', function(t) {
+  t.plan(9)
+  t.timeoutAfter(10000)
 
   budo('test/app.js', {
     dir: __dirname,
@@ -14,19 +15,86 @@ test('should provide an API', function(t) {
   .on('error', function(err) {
     t.fail(err)
   })
-  .on('connect', function(ev) {
+  .on('connect', function(app) {
     var file = path.join(__dirname, 'bundle.js')
-    t.equal(ev.to, 'bundle.js', 'mapping matches')
-    t.equal(ev.from, file, 'from matches')
-    t.equal(ev.uri, 'http://localhost:8000/', 'uri matches')
-    t.equal(ev.host, 'localhost', 'host is not specified')
-    t.equal(ev.port, 8000, 'port matches')
-    t.equal(ev.glob, file, 'glob matches file')
-    t.equal(ev.dir, __dirname, 'dir matches')
-    setTimeout(function() {
-      ev.close()
-      cleanup()
-    }, 1000)
+    t.equal(app.to, 'bundle.js', 'mapping matches')
+    t.equal(app.from, file, 'from matches')
+    t.equal(app.uri, 'http://localhost:8000/', 'uri matches')
+    t.equal(app.host, 'localhost', 'host is not specified')
+    t.equal(app.port, 8000, 'port matches')
+    t.equal(app.glob, file, 'glob matches file')
+    t.equal(app.dir, __dirname, 'dir matches')
+
+    app
+      .watch()
+      .once('watch', function(type) {
+        t.ok(true, 'got watch')
+        app.close()
+        cleanup()
+      })
+  })
+  .on('reload', function() {
+    t.fail('should not have received reload event')
+  })
+  .on('exit', function() {
+    t.ok(true, 'closing')
+  })
+})
+
+test('sets watch() with args before connect', function(t) {
+  t.plan(3)
+  t.timeoutAfter(10000)
+
+  var app = budo('test/app.js', {
+    dir: __dirname,
+    port: 8000,
+    outfile: 'bundle.js'
+  })
+  .watch() //enable watcher
+  .once('watch', function() {
+    t.ok(true, 'got watch')
+    app.close()
+    cleanup()
+  })
+  .on('error', function(err) {
+    t.fail(err)
+  })
+  .on('reload', function() {
+    t.fail('should not have received reload event')
+  })
+  .on('connect', function(app) {
+    var file = path.join(__dirname, 'bundle.js')
+    t.equal(app.from, file, 'from matches')
+  })
+  .on('exit', function() {
+    t.ok(true, 'closing')
+  })
+})
+
+test('sets watch() and live() by default with live: true', function(t) {
+  t.plan(4)
+  t.timeoutAfter(10000)
+
+  var app = budo('test/app.js', {
+    dir: __dirname,
+    port: 8000,
+    live: true,
+    outfile: 'bundle.js'
+  })
+  .once('reload', function(err) {
+    t.ok(true, 'got reload event')
+    app.close()
+    cleanup()
+  })
+  .once('watch', function() {
+    t.ok(true, 'got watch event')    
+  })
+  .on('error', function(err) {
+    t.fail(err)
+  })
+  .on('connect', function(app) {
+    var file = path.join(__dirname, 'bundle.js')
+    t.equal(app.from, file, 'from matches')
   })
   .on('exit', function() {
     t.ok(true, 'closing')

--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -12,15 +12,12 @@ var request = require('request')
 
 var cliPath = path.resolve(__dirname, '..', 'bin', 'cmd.js')
 
-// Some other tests needed:
-// --live
-// --live-plugin
-
 test('should fail without scripts', function(t) {
   t.plan(1)
   var proc = spawn(cliPath)
   proc.stderr.pipe(concat(function(str) {
-    t.equal(str.toString().trim(), 'No entry scripts specified!')
+    var msg = str.toString().toLowerCase()
+    t.notEqual(msg.indexOf('no entry scripts specified'), -1)
   }))
 })
 


### PR DESCRIPTION
Source cleanup, watchify@3.0, decoupling LiveReload/watch

- moving to 2 spaces for whitespacing
- removing `wtch` since it was leading to more complexity than it's worth
- decoupling watch from LiveReload since you often may only need one
- adding `live()` and `watch()` methods
- cleaning up the budo API so that there is just one emitter (the budo instance) rather than two
- supporting `--poll` and `--ignore-watch` options in watchify@3 and sending them to file-watch for live reload
- adding help messages
- improving error messages when watchify is not found or when no entries are given