### PR TITLE
fixed tinylr params

### DIFF
--- a/lib/tinylr.js
+++ b/lib/tinylr.js
@@ -3,7 +3,7 @@ var log = require('bole')('budo')
 var xtend = require('xtend')
 var tinylr = require('tiny-lr')
 
-module.exports = function(glob, opt) {
+module.exports = function(opt) {
   opt = xtend(opt)
   opt.host = opt.host || 'localhost'
   if (typeof opt.port !== 'number')


### PR DESCRIPTION
When binding to something else than localhost, livereload doesn't obey the `opts.host`.

Removed the `glob` param to be consistent with the call [here](https://github.com/mattdesl/budo/blob/master/lib/budo.js#L88).

Thanks for the awesome tool :)