### PR TITLE
add path option for setting pathname of url

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Options:
   --live-plugin    enable LiveReload but do not inject script tag
   --live-port      the LiveReload port, default 35729
   --verbose, -v    verbose timing information for re-bundles
+  --path           set url pathname for files served by budo, default "/"
   --poll=N         use polling for file watch, with optional interval N
   --no-stream      do not print messages to stdout
   --no-debug       do not use inline source maps

--- a/bin/help.txt
+++ b/bin/help.txt
@@ -11,6 +11,7 @@ Options:
   --live-plugin    enable LiveReload but do not inject script tag
   --live-port      the LiveReload port, default 35729
   --verbose, -v    verbose timing information for re-bundles
+  --path           set url pathname for files served by budo, default "/"
   --poll=N         use polling for file watch, with optional interval N
   --no-stream      do not print messages to stdout
   --no-debug       do not use inline source maps

--- a/lib/budo.js
+++ b/lib/budo.js
@@ -35,6 +35,7 @@ module.exports = function() {
       .listen(port, opt.host, function() {
         var hostname = (opt.host || 'localhost')
         var uri = "http://" + hostname + ":" + opt.port + "/"
+        if (opt.path) uri += opt.path
 
         log.info({ message: "Server running at " + uri, type: 'connect', url: uri })
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -53,7 +53,7 @@ function createHandler(opts) {
   emitter.contents = ''
 
   var pathname = opts.path ?  '/' + url.parse(opts.path).pathname : '/'
-  console.log(pathname)
+
   router.addRoute(pathname + url.parse(opts.serve).pathname, function(req, res) {
     log.info({
       url: req.url,
@@ -81,12 +81,13 @@ function createHandler(opts) {
   function wildcard(html) {
 
     return function(req, res) {
+      var fullurl = req.url
       req.url = req.url.replace(pathname, '/')
       //inject LiveReload into HTML content if needed
       if (html && emitter.live)
         res = inject(res, emitter.live)
       log.info({
-        url: req.url,
+        url: fullurl,
         type: 'static'
       })
       staticHandler(req, res)
@@ -102,6 +103,7 @@ function createHandler(opts) {
   }
 
   function home(req, res) {
+    var fullurl = req.url
     req.url = req.url.replace(pathname, '/')
     fs.exists(path.join(basedir, 'index.html'), function(exists) {
       //inject LiveReload into HTML content if needed
@@ -110,7 +112,7 @@ function createHandler(opts) {
 
       var type = exists ? 'static' : 'generated'
       log.info({
-        url: req.url,
+        url: fullurl,
         type: type
       })
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -52,12 +52,14 @@ function createHandler(opts) {
   emitter.pending = false
   emitter.contents = ''
 
-  router.addRoute('/' + url.parse(opts.serve).pathname, function(req, res) {
+  var pathname = opts.path ?  '/' + url.parse(opts.path).pathname : '/'
+  console.log(pathname)
+  router.addRoute(pathname + url.parse(opts.serve).pathname, function(req, res) {
     log.info({
       url: req.url,
       type: 'static'
     })  
-    
+
     if (emitter.pending) {
       log.debug("bundle pending")
       emitter.once('update', function() {
@@ -69,15 +71,17 @@ function createHandler(opts) {
     }
   })
 
-  router.addRoute('/index.html', home)
-  router.addRoute('/', home)
+  router.addRoute(pathname + '/index.html', home)
+  router.addRoute(pathname, home)
   router.addRoute('*.html', wildcard(true))
   router.addRoute('*', wildcard())
 
   return emitter
 
   function wildcard(html) {
+
     return function(req, res) {
+      req.url = req.url.replace(pathname, '/')
       //inject LiveReload into HTML content if needed
       if (html && emitter.live)
         res = inject(res, emitter.live)
@@ -98,6 +102,7 @@ function createHandler(opts) {
   }
 
   function home(req, res) {
+    req.url = req.url.replace(pathname, '/')
     fs.exists(path.join(basedir, 'index.html'), function(exists) {
       //inject LiveReload into HTML content if needed
       if (emitter.live)


### PR DESCRIPTION
Sometimes I'm working on a project that will get published under a pathname. Github pages projects are a good example: `username.github.io/project`.

This adds a `--path` option to the cli so that if it is used like this: `budo index.js --path project`

Files will be available at this url: `http://localhost:9966/project`