### PR TITLE
Always serve index page for --pushstate

### DIFF
--- a/bin/help.txt
+++ b/bin/help.txt
@@ -10,6 +10,7 @@ Options:
   --live           enable LiveReload integration
   --live-plugin    enable LiveReload but do not inject script tag
   --live-port      the LiveReload port, default 35729
+  --pushstate      always render the index page instead of a 404 page
   --verbose, -v    verbose timing information for re-bundles
   --poll=N         use polling for file watch, with optional interval N
   --no-stream      do not print messages to stdout

--- a/lib/server.js
+++ b/lib/server.js
@@ -76,6 +76,19 @@ function createHandler(opts) {
 
   return emitter
 
+  function pushstate(req, res) {
+    staticHandler(req, res, function () {
+      if (opts.pushstate) {
+        // reset for home
+        req.url = '/'
+        res.statusCode = 200
+        home(req, res)
+      } else {
+        res.end()
+      }
+    })
+  }
+
   function wildcard(html) {
     return function(req, res) {
       //inject LiveReload into HTML content if needed
@@ -85,7 +98,7 @@ function createHandler(opts) {
         url: req.url,
         type: 'static'
       })
-      staticHandler(req, res)
+      pushstate(req, res)
     }
   }
 


### PR DESCRIPTION
For applications that utilize HTML5 pushstate to mange the URL, it's
desirable for the server to always return the index.html page instead of
a 404.

Passing `--pushstate` on the command line will return the index.html if
no other resource matches the path.

Issue: #41