### PR TITLE
Replace tiny-lr with mini-lr for npm v3 support

### DIFF
--- a/lib/budo.js
+++ b/lib/budo.js
@@ -11,7 +11,7 @@ var getPorts = require('./get-ports')
 var createServer = require('./server')
 var createBundler = require('./bundler')
 var createFileWatch = require('./file-watch')
-var createTinylr = require('./tinylr')
+var createMiniLr = require('./minilr')
 var mapEntry = require('./map-entry')
 
 var noop = function () {}
@@ -91,7 +91,7 @@ function createBudo (entries, opts) {
   var closed = false
   var started = false
   var fileWatcher = null
-  var tinylr = null
+  var minilr = null
   var deferredWatch = noop
   var deferredLive = noop
 
@@ -131,8 +131,8 @@ function createBudo (entries, opts) {
 
   function reload (file) {
     process.nextTick(emitter.emit.bind(emitter, 'reload', file))
-    if (tinylr) {
-      tinylr.reload(file)
+    if (minilr) {
+      minilr.reload(file)
     }
   }
 
@@ -159,7 +159,7 @@ function createBudo (entries, opts) {
       deferredLive = emitter.live.bind(null, liveOpts)
     } else {
       // destroy previous
-      if (tinylr) tinylr.close()
+      if (minilr) minilr.close()
 
       liveOpts = xtend({
         host: opts.host,
@@ -168,7 +168,7 @@ function createBudo (entries, opts) {
 
       // inject script tag into HTML requests
       server.setLiveOptions(liveOpts)
-      tinylr = createTinylr(liveOpts)
+      minilr = createMiniLr(liveOpts)
     }
     return emitter
   }
@@ -245,7 +245,7 @@ function createBudo (entries, opts) {
     }
 
     if (started) server.close()
-    if (tinylr) tinylr.close()
+    if (minilr) minilr.close()
     if (bundler) bundler.close()
     if (fileWatcher) fileWatcher.close()
     closed = true

--- a/lib/minilr.js
+++ b/lib/minilr.js
@@ -1,7 +1,7 @@
-// a thin wrapper around tiny-lr module
+// a thin wrapper around mini-lr module
 var log = require('bole')('budo')
 var xtend = require('xtend')
-var tinylr = require('tiny-lr')
+var minilr = require('mini-lr')
 
 module.exports = function (opt) {
   opt = xtend(opt)
@@ -10,7 +10,7 @@ module.exports = function (opt) {
     opt.port = 35729
   }
 
-  var server = tinylr({
+  var server = minilr({
     livereload: require.resolve('livereload-js/dist/livereload.js')
   })
   var closed = false

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "internal-ip": "^1.0.1",
     "livereload-js": "^2.2.2",
     "micromatch": "^2.2.0",
+    "mini-lr": "^0.1.8",
     "minimist": "^1.1.0",
     "once": "^1.3.2",
     "opn": "^3.0.2",
@@ -32,7 +33,6 @@
     "simple-html-index": "^1.1.0",
     "strip-ansi": "^3.0.0",
     "term-color": "^1.0.1",
-    "tiny-lr": "^0.1.5",
     "watchify-middleware": "^1.3.0",
     "xtend": "^4.0.0"
   },

--- a/test/test-close-immediate.js
+++ b/test/test-close-immediate.js
@@ -1,7 +1,7 @@
 var test = require('tape')
 var budo = require('../')
 
-// watchify, chokidar and tinylr are a bit stubborn
+// watchify, chokidar and minilr are a bit stubborn
 // if you try to close them immediately after starting
 // the watchers.
 test('can close on connect with watch/live', function (t) {


### PR DESCRIPTION
Tiny-lr has an issue with npm v3's flat module directory, reference [here](https://github.com/mklabs/tiny-lr/issues/91).

However, the project hasn't been updated in quite some time, and the maintainers have a history of abandoning it.  In order to unblock npm v3 users, I've forked the project and released it under the name `mini-lr`. You can find the new repository [here](http://jhawk.co/mini-lr). I recommend updating your project to use the latest release in order to enable npm v3 usage. Thanks!