### PR TITLE
use default ports if empty/invalid (fixes #110)

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,14 @@ function budoCLI (args, opts) {
     argv.livePort = parseInt(argv.livePort, 10)
   }
 
+  // port and livePort must be valid numbers
+  if (isNaN(argv.port)) {
+    delete argv.port
+  }
+  if (isNaN(argv.livePort)) {
+    delete argv.livePort
+  }
+
   // opts.live can be a glob or a boolean
   if (typeof argv.live === 'string' && /(true|false)/.test(argv.live)) {
     argv.live = argv.live === 'true'


### PR DESCRIPTION
my use case is wanting the port to not start at `9966` by default

see https://github.com/mattdesl/budo/issues/110#issue-120142485 and https://github.com/mattdesl/budo/issues/110#issuecomment-161637237

let me know if there's any way I can make this change kosher