### PR TITLE
Serve files if requested by full local path.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -150,6 +150,12 @@ function createServer (entryHandler, opts) {
           res.statusCode = 200
           home(req, res)
         } else {
+          if (fs.existsSync(req.url)) {
+            var bytes = fs.readFileSync(req.url)
+            res.statusCode = 200
+            res.end(bytes)
+            return
+          }
           res.statusCode = 404
           res.end('404 not found: ' + req.url)
         }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "budo",
+  "name": "budo-marcuswestin-fix",
   "version": "7.0.4",
   "description": "a browserify server for rapid prototyping",
   "main": "index.js",
@@ -76,7 +76,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/mattdesl/budo.git"
+    "url": "git://github.com/marcuswestin/budo.git"
   },
   "homepage": "https://github.com/mattdesl/budo",
   "bugs": {


### PR DESCRIPTION
Chrome dev tools may request files by local file path during development when viewing the file in the "sources" tab. Before this patch, budo would respond with a 404. With this patch, budo responds with the content of the target file from local disk.