### PR TITLE
Absolute path to bundle

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -117,9 +117,9 @@ function budoMiddleware (entryMiddleware, opts) {
 
       var stream = opts.defaultIndex || defaultIndex
       stream({
-        entry: entrySrc,
+        entry: entrySrc && '/' + entrySrc,
         title: opts.title,
-        css: opts.css
+        css: opts.css && '/' + opts.css
       }).pipe(res)
     } else {
       next()

--- a/test/test-entries.js
+++ b/test/test-entries.js
@@ -7,7 +7,7 @@ var entryMap = require('../lib/map-entry')
 
 // an HTML page with no <script> entry
 var defaultIndex = '<!doctype html><head><title>budo</title><meta charset="utf-8"></head><body></body></html>'
-var scriptIndex = '<!doctype html><head><title>budo</title><meta charset="utf-8"></head><body><script src="foo.js"></script></body></html>'
+var scriptIndex = '<!doctype html><head><title>budo</title><meta charset="utf-8"></head><body><script src="/foo.js"></script></body></html>'
 
 test('accept "." entry point', function (t) {
   // currently we can't test budo('.') because the index.js

--- a/test/test-live.js
+++ b/test/test-live.js
@@ -135,13 +135,13 @@ function matchesHTML (t, uri, html, cb) {
 }
 
 function getHTMLNoLive () {
-  return '<!doctype html><head><title>budo</title><meta charset="utf-8"></head><body><script src="app.js"></script></body></html>'
+  return '<!doctype html><head><title>budo</title><meta charset="utf-8"></head><body><script src="/app.js"></script></body></html>'
 }
 
 function getHTML () {
-  return '<!doctype html><head><title>budo</title><meta charset="utf-8"></head><body><script type="text/javascript" src="//localhost:35729/livereload.js?snipver=1" async="" defer=""></script><script src="app.js"></script></body></html>'
+  return '<!doctype html><head><title>budo</title><meta charset="utf-8"></head><body><script type="text/javascript" src="//localhost:35729/livereload.js?snipver=1" async="" defer=""></script><script src="/app.js"></script></body></html>'
 }
 
 function getHTMLWithHost (ip) {
-  return '<!doctype html><head><title>budo</title><meta charset="utf-8"></head><body><script type="text/javascript" src="//' + ip + ':35729/livereload.js?snipver=1" async="" defer=""></script><script src="app.js"></script></body></html>'
+  return '<!doctype html><head><title>budo</title><meta charset="utf-8"></head><body><script type="text/javascript" src="//' + ip + ':35729/livereload.js?snipver=1" async="" defer=""></script><script src="/app.js"></script></body></html>'
 }

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -44,7 +44,7 @@ test('support defaultIndex stream', function (t) {
       }, function (err, resp, body) {
         if (err) t.fail(err)
         t.equal(resp.statusCode, 200)
-        t.equal(body, '<!doctype html><head><title>foobar</title><meta charset="utf-8"><link rel="stylesheet" href="main.css"></head><body><script src="app.js"></script></body></html>')
+        t.equal(body, '<!doctype html><head><title>foobar</title><meta charset="utf-8"><link rel="stylesheet" href="main.css"></head><body><script src="/app.js"></script></body></html>')
         app.close()
       })
     })
@@ -68,7 +68,7 @@ test('support --title and --css', function (t) {
       }, function (err, resp, body) {
         if (err) t.fail(err)
         t.equal(resp.statusCode, 200)
-        t.equal(body, '<!doctype html><head><title>foobar</title><meta charset="utf-8"><link rel="stylesheet" href="main.css"></head><body><script src="app.js"></script></body></html>')
+        t.equal(body, '<!doctype html><head><title>foobar</title><meta charset="utf-8"><link rel="stylesheet" href="/main.css"></head><body><script src="/app.js"></script></body></html>')
         app.close()
       })
     })


### PR DESCRIPTION
The path to the bundle is resolved incorrectly with `--pushstate` enabled. This fixes it by making the path absolute.