### PR TITLE
Bump watchify-middleware to 1.6 (w/ bundle method)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "term-color": "^1.0.1",
     "tiny-lr": "^0.2.0",
     "url-trim": "^1.0.0",
-    "watchify-middleware": "^1.3.0",
+    "watchify-middleware": "^1.6.0",
     "xtend": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
1.6 is actually required and the server will throw on boot if <1.6 is used