### PR TITLE
added --proxy path@url command line argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Options:
   --no-portfind    will not attempt auto-portfinding
   --no-error-handler    disable default DOM error handling
   --watch-glob, --wg    glob(s) to watch for reloads, default '**/*.{html,css}'
+  --proxy path@url      proxy requests on given path to url (eg: --proxy /api@http://localhost:3000/api)
 ```
 
 By default, messages will be printed to `process.stdout`, and `--debug` will be sent to browserify (for source maps). You can turn these off with `--no-stream` and `--no-debug`, respectively.

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -8,6 +8,9 @@ var pushState = require('connect-pushstate')
 var liveReload = require('inject-lr-script')
 var urlTrim = require('url-trim')
 
+var argv = require('./parse-args.js')(process.argv.slice(2))
+var httpProxy = require('http-proxy')
+
 module.exports = budoMiddleware
 function budoMiddleware (entryMiddleware, opts) {
   opts = opts || {}
@@ -87,6 +90,19 @@ function budoMiddleware (entryMiddleware, opts) {
   // Generates a default index.html
   // when none is found locally.
   handler.use(indexHandler)
+
+  // Attach proxy
+  if (argv.proxy) {
+    console.log('Attaching proxy at: ' + argv.proxy)
+    var split = argv.proxy.trim().split('@')
+    var proxy = httpProxy.createProxyServer({});
+    handler.mount(split[0], function (req, res, next) {
+      console.log('-- proxying -- : ' + split[1] + req.url)
+      proxy.web(req, res, { target: split[1] + req.url }, function (err) {
+        if (err) next()
+      })
+    })
+  }
 
   // Handle errors
   handler.use(function (req, res) {

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -95,7 +95,7 @@ function budoMiddleware (entryMiddleware, opts) {
   if (argv.proxy) {
     console.log('Attaching proxy at: ' + argv.proxy)
     var split = argv.proxy.trim().split('@')
-    var proxy = httpProxy.createProxyServer({});
+    var proxy = httpProxy.createProxyServer({})
     handler.mount(split[0], function (req, res, next) {
       console.log('-- proxying -- : ' + split[1] + req.url)
       proxy.web(req, res, { target: split[1] + req.url }, function (err) {

--- a/lib/parse-args.js
+++ b/lib/parse-args.js
@@ -24,7 +24,8 @@ function parseArgs (args, opt) {
       'title',
       'watchGlob',
       'cert',
-      'key'
+      'key',
+      'proxy'
     ],
     default: module.exports.defaults,
     alias: {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "events": "^1.0.2",
     "garnish": "^5.0.0",
     "get-ports": "^1.0.2",
+    "http-proxy": "^1.13.3",
     "inject-lr-script": "^2.0.0",
     "internal-ip": "^1.0.1",
     "micromatch": "^2.2.0",


### PR DESCRIPTION
eg: `--proxy /api@http://localhost:3000/api`

Proxies request to given url from given path (for example when proxying to API server)

working sample:

`budo scripts/main.js --live --proxy /api@http://localhost:3030/api -- -t rollupify -t sassr -t babelify`