### PR TITLE
add callback in opts to pass server instance as argument

### DIFF
--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -77,6 +77,8 @@ All settings are optional.
   - if specified, this will be used to construct the new instance
 - `middleware` (Array|Function)
   - an optional function or array of `fn(req, res, next)` functions for the server which is run before other routes; using `connect` style middleware
+- `serverCallback` (Function)
+  - an optional function `fn(server)` that is called with reference to the server instance for external use - to attach socket.io for example
 - `errorHandler` (Boolean|Function)
   - whether to include a DOM-based reporter build/syntax errors (default `true`)
   - can be a `reporter(err)` function which takes an Error and returns the new bundle contents

--- a/lib/budo.js
+++ b/lib/budo.js
@@ -113,13 +113,18 @@ function createBudo (entries, opts) {
   }
 
   var defaultWatchGlob = opts.watchGlob || '**/*.{html,css}'
-  var server = createServer(middleware, opts)
   var closed = false
   var started = false
   var fileWatcher = null
   var tinylr = null
   var deferredWatch = noop
   var deferredLive = noop
+
+  // create server, and optionally pass reference to opts.serverCallback function
+  var server = createServer(middleware, opts)
+  if(typeof opts.serverCallback === 'function') {
+    opts.serverCallback(server);
+  }
 
   // keep track of the original host
   // (can be undefined)


### PR DESCRIPTION
I wanted to add socket.io config to budo server, so I needed instance of server to pass to socket.io during initialisation, something like this...

    var budo = budo = require('../budo');

    var server = budo('app.js', {
        port: 8080,
        serverCallback: attachSocketIO
    })

    function attachSocketIO(server){
        var io = require('socket.io')(server);
        io.sockets.on('connection', function (socket) { /* hooray for web sockets..! */ });
    }