### PR TITLE
Insert base tag in generated HTML page for pushstate

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Options:
   --live-port, -L  the LiveReload port, default 35729
   --open, -o       launch the browser once connected
   --pushstate, -P  always render the index page instead of a 404 page
+  --base           set the base path for the generated HTML, default to '/'
   --onupdate       a shell command to trigger on bundle update
   --poll=N         use polling for file watch, with optional interval N
   --title          optional title for default index.html

--- a/bin/help.txt
+++ b/bin/help.txt
@@ -12,6 +12,7 @@ Options:
   --live-port, -L  the LiveReload port, default 35729
   --open, -o       launch the browser once connected
   --pushstate, -P  always render the index page instead of a 404 page
+  --base           set the base path for the generated HTML, default to '/'
   --onupdate       a shell command to trigger on bundle update
   --poll=N         use polling for file watch, with optional interval N
   --title          optional title for default index.html

--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -83,6 +83,8 @@ All settings are optional.
 - `pushstate` (Boolean)
   - enable push state support, which defaults 404 routes to the index (default `false`)
   - Recommended you also add something like `<base href="/">` to your HTML `<head>`
+- `base` (Boolean|String)
+  - add `<base href="/">` to the generated default HTML page if set to true, or uses the specified path if it's a string
 - `verbose` (Boolean)
   - also print `'debug'` level messages to garnish; such as the pending state of the bundle and how many files changed in the last update.
 - `defaultIndex` (Function)

--- a/docs/command-line-usage.md
+++ b/docs/command-line-usage.md
@@ -160,6 +160,8 @@ It is suggested you add a `<base>` in your `index.html` for this to work with ne
 </head>
 ```
 
+If you let budo generate a default HTML page, you can add the `<base>` tag using `--base` or `--base /my-path`.
+
 ## hot module replacement
 
 The following can integrate easily with budo:

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -121,7 +121,8 @@ function budoMiddleware (entryMiddleware, opts) {
       stream({
         entry: entrySrc,
         title: opts.title,
-        css: opts.css
+        css: opts.css,
+        base: opts.base === true ? '/' : (opts.base || null)
       }).pipe(res)
     } else {
       next()

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "resolve": "^1.1.6",
     "resp-modifier": "^6.0.0",
     "serve-static": "^1.10.0",
-    "simple-html-index": "^1.1.0",
+    "simple-html-index": "^1.4.0",
     "stacked": "^1.1.1",
     "stdout-stream": "^1.4.0",
     "strip-ansi": "^3.0.0",

--- a/test/test-base.js
+++ b/test/test-base.js
@@ -1,0 +1,37 @@
+var test = require('tape')
+var budo = require('../')
+var path = require('path')
+var request = require('request')
+
+var file = path.join(__dirname, 'fixtures', 'app.js')
+var html = '<!DOCTYPE html><html lang="en"><head><title>budo</title><meta charset="utf-8"><base href="${base}"></head><body><script src="app.js"></script></body></html>'
+
+test('base default', function (t) {
+  t.plan(1)
+  var b = budo(file, {
+    port: 9966,
+    base: true,
+    portfind: false
+  }).on('connect', function (ev) {
+    request({ uri: ev.uri }, function (err, resp, body) {
+      b.close()
+      if (err) return t.fail(err)
+      t.equal(body, html.replace('${base}', '/'), 'returns home index.html')
+    })
+  })
+})
+
+test('base with value', function (t) {
+  t.plan(1)
+  var b = budo(file, {
+    port: 9966,
+    base: '/xyz',
+    portfind: false
+  }).on('connect', function (ev) {
+    request({ uri: ev.uri }, function (err, resp, body) {
+      b.close()
+      if (err) return t.fail(err)
+      t.equal(body, html.replace('${base}', '/xyz'), 'returns home index.html')
+    })
+  })
+})

--- a/test/test-entries.js
+++ b/test/test-entries.js
@@ -6,8 +6,8 @@ var path = require('path')
 var entryMap = require('../lib/map-entry')
 
 // an HTML page with no <script> entry
-var defaultIndex = '<!doctype html><head><title>budo</title><meta charset="utf-8"></head><body></body></html>'
-var scriptIndex = '<!doctype html><head><title>budo</title><meta charset="utf-8"></head><body><script src="foo.js"></script></body></html>'
+var defaultIndex = '<!DOCTYPE html><html lang="en"><head><title>budo</title><meta charset="utf-8"></head><body></body></html>'
+var scriptIndex = '<!DOCTYPE html><html lang="en"><head><title>budo</title><meta charset="utf-8"></head><body><script src="foo.js"></script></body></html>'
 
 test('accept "." entry point', function (t) {
   // currently we can't test budo('.') because the index.js

--- a/test/test-live.js
+++ b/test/test-live.js
@@ -135,13 +135,13 @@ function matchesHTML (t, uri, html, cb) {
 }
 
 function getHTMLNoLive () {
-  return '<!doctype html><head><title>budo</title><meta charset="utf-8"></head><body><script src="app.js"></script></body></html>'
+  return '<!DOCTYPE html><html lang="en"><head><title>budo</title><meta charset="utf-8"></head><body><script src="app.js"></script></body></html>'
 }
 
 function getHTML () {
-  return '<!doctype html><head><title>budo</title><meta charset="utf-8"></head><body><script type="text/javascript" src="//localhost:35729/livereload.js?snipver=1" async="" defer=""></script><script src="app.js"></script></body></html>'
+  return '<!DOCTYPE html><html lang="en"><head><title>budo</title><meta charset="utf-8"></head><body><script type="text/javascript" src="//localhost:35729/livereload.js?snipver=1" async="" defer=""></script><script src="app.js"></script></body></html>'
 }
 
 function getHTMLWithHost (ip) {
-  return '<!doctype html><head><title>budo</title><meta charset="utf-8"></head><body><script type="text/javascript" src="//' + ip + ':35729/livereload.js?snipver=1" async="" defer=""></script><script src="app.js"></script></body></html>'
+  return '<!DOCTYPE html><html lang="en"><head><title>budo</title><meta charset="utf-8"></head><body><script type="text/javascript" src="//' + ip + ':35729/livereload.js?snipver=1" async="" defer=""></script><script src="app.js"></script></body></html>'
 }

--- a/test/test-pushstate.js
+++ b/test/test-pushstate.js
@@ -4,7 +4,7 @@ var path = require('path')
 var request = require('request')
 
 var file = path.join(__dirname, 'fixtures', 'app.js')
-var html = '<!doctype html><head><title>budo</title><meta charset="utf-8"></head><body><script src="app.js"></script></body></html>'
+var html = '<!DOCTYPE html><html lang="en"><head><title>budo</title><meta charset="utf-8"></head><body><script src="app.js"></script></body></html>'
 
 test('pushstate', function (t) {
   t.plan(1)

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -44,7 +44,7 @@ test('support defaultIndex stream', function (t) {
       }, function (err, resp, body) {
         if (err) t.fail(err)
         t.equal(resp.statusCode, 200)
-        t.equal(body, '<!doctype html><head><title>foobar</title><meta charset="utf-8"><link rel="stylesheet" href="main.css"></head><body><script src="app.js"></script></body></html>')
+        t.equal(body, '<!DOCTYPE html><html lang="en"><head><title>foobar</title><meta charset="utf-8"><link rel="stylesheet" href="main.css"></head><body><script src="app.js"></script></body></html>')
         app.close()
       })
     })
@@ -68,7 +68,7 @@ test('support --title and --css', function (t) {
       }, function (err, resp, body) {
         if (err) t.fail(err)
         t.equal(resp.statusCode, 200)
-        t.equal(body, '<!doctype html><head><title>foobar</title><meta charset="utf-8"><link rel="stylesheet" href="main.css"></head><body><script src="app.js"></script></body></html>')
+        t.equal(body, '<!DOCTYPE html><html lang="en"><head><title>foobar</title><meta charset="utf-8"><link rel="stylesheet" href="main.css"></head><body><script src="app.js"></script></body></html>')
         app.close()
       })
     })


### PR DESCRIPTION
This improves / fixes the pushstate generated HTML page as discussed in #159 and builds on top of a new feature introduced in https://github.com/mattdesl/simple-html-index/pull/11.

There are two commits:

- The first fixes the tests according to the changes that where made in `simple-html-index` unrelated to the base URL feature.
- The second commit contains the actual changes relevant for the pushstate base URL issue.