### PR TITLE
Bundle if browserify entries specified

### DIFF
--- a/lib/budo.js
+++ b/lib/budo.js
@@ -75,7 +75,7 @@ function createBudo (entries, opts) {
   var emitter = new EventEmitter()
   var bundler, middleware
 
-  if (entries.length > 0) {
+  if (entries.length > 0 || (opts.browserify && opts.browserify.entries)) {
     bundler = createBundler(entryFiles, opts)
     middleware = bundler.middleware
 

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -89,6 +89,23 @@ test('--serve allows explicit bundle renaming', function (t) {
     })
 })
 
+test('bundles if entries passed via browserify opts', function (t) {
+  t.plan(2)
+  t.timeoutAfter(5000)
+
+  var app = budo({
+    serve: 'static/foo.js',
+    browserify: {
+      entries: ['test/fixtures/app', 'test/fixtures/with space.js']
+    }
+  })
+    .on('connect', function (ev) {
+      t.equal(ev.serve, 'static/foo.js', 'mapping matches')
+      t.deepEqual(ev.entries, [], 'from matches')
+      app.close()
+    })
+})
+
 test('sets watch() and live() by default with live: true', function (t) {
   t.plan(4)
   t.timeoutAfter(3000)


### PR DESCRIPTION
This allows for bundling even when no entries are passed to budo directly.

This is useful when specifying stream entries (via the `entries` field in the browserify opts), which budo won't accept but browserify will.

I'm not quire sure how the `ev.entries` in the `connect` callback should be handled in this case, since it could be a stream (rather than file), but for now, simply using an empty array seemed ok.

This seemed cleaner than having some `--always-bundle` boolean flag, but it's sort of implicit. I'm happy to make whatever changes are needed. Basically I just want to use budo programmatically with a generated entry file that is not actually written to the file system.