### PR TITLE
es5-version-of-fixes-for-tests

### DIFF
--- a/test/fixtures/three/index.html
+++ b/test/fixtures/three/index.html
@@ -1,1 +1,1 @@
-<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>THREE</title></head><body></body></html>
+<!DOCTYPE html><html lang="en" dir="ltr"><head><meta charset="UTF-8"><title>THREE</title></head><body></body></html>

--- a/test/fixtures/two/index.html
+++ b/test/fixtures/two/index.html
@@ -1,1 +1,1 @@
-<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>TWO</title></head><body></body></html>
+<!DOCTYPE html><html lang="en" dir="ltr"><head><meta charset="UTF-8"><title>TWO</title></head><body></body></html>

--- a/test/test-base.js
+++ b/test/test-base.js
@@ -4,7 +4,7 @@ var path = require('path')
 var request = require('request')
 
 var file = path.join(__dirname, 'fixtures', 'app.js')
-var html = '<!DOCTYPE html><html lang="en"><head><title>budo</title><meta charset="utf-8"><base href="${base}"></head><body><script src="app.js"></script></body></html>'
+var html = '<!DOCTYPE html><html lang="en" dir="ltr"><head><title>budo</title><meta charset="utf-8"><base href="${base}"></head><body><script src="app.js"></script></body></html>'
 
 test('base default', function (t) {
   t.plan(1)

--- a/test/test-entries.js
+++ b/test/test-entries.js
@@ -6,8 +6,8 @@ var path = require('path')
 var entryMap = require('../lib/map-entry')
 
 // an HTML page with no <script> entry
-var defaultIndex = '<!DOCTYPE html><html lang="en"><head><title>budo</title><meta charset="utf-8"></head><body></body></html>'
-var scriptIndex = '<!DOCTYPE html><html lang="en"><head><title>budo</title><meta charset="utf-8"></head><body><script src="foo.js"></script></body></html>'
+var defaultIndex = '<!DOCTYPE html><html lang="en" dir="ltr"><head><title>budo</title><meta charset="utf-8"></head><body></body></html>'
+var scriptIndex = '<!DOCTYPE html><html lang="en" dir="ltr"><head><title>budo</title><meta charset="utf-8"></head><body><script src="foo.js"></script></body></html>'
 
 test('accept "." entry point', function (t) {
   // currently we can't test budo('.') because the index.js

--- a/test/test-live.js
+++ b/test/test-live.js
@@ -135,13 +135,13 @@ function matchesHTML (t, uri, html, cb) {
 }
 
 function getHTMLNoLive () {
-  return '<!DOCTYPE html><html lang="en"><head><title>budo</title><meta charset="utf-8"></head><body><script src="app.js"></script></body></html>'
+  return '<!DOCTYPE html><html lang="en" dir="ltr"><head><title>budo</title><meta charset="utf-8"></head><body><script src="app.js"></script></body></html>'
 }
 
 function getHTML () {
-  return '<!DOCTYPE html><html lang="en"><head><title>budo</title><meta charset="utf-8"></head><body><script type="text/javascript" src="//localhost:35729/livereload.js?snipver=1" async="" defer=""></script><script src="app.js"></script></body></html>'
+  return '<!DOCTYPE html><html lang="en" dir="ltr"><head><title>budo</title><meta charset="utf-8"></head><body><script type="text/javascript" src="//localhost:35729/livereload.js?snipver=1" async="" defer=""></script><script src="app.js"></script></body></html>'
 }
 
 function getHTMLWithHost (ip) {
-  return '<!DOCTYPE html><html lang="en"><head><title>budo</title><meta charset="utf-8"></head><body><script type="text/javascript" src="//' + ip + ':35729/livereload.js?snipver=1" async="" defer=""></script><script src="app.js"></script></body></html>'
+  return '<!DOCTYPE html><html lang="en" dir="ltr"><head><title>budo</title><meta charset="utf-8"></head><body><script type="text/javascript" src="//' + ip + ':35729/livereload.js?snipver=1" async="" defer=""></script><script src="app.js"></script></body></html>'
 }

--- a/test/test-pushstate.js
+++ b/test/test-pushstate.js
@@ -4,7 +4,7 @@ var path = require('path')
 var request = require('request')
 
 var file = path.join(__dirname, 'fixtures', 'app.js')
-var html = '<!DOCTYPE html><html lang="en"><head><title>budo</title><meta charset="utf-8"></head><body><script src="app.js"></script></body></html>'
+var html = '<!DOCTYPE html><html lang="en" dir="ltr"><head><title>budo</title><meta charset="utf-8"></head><body><script src="app.js"></script></body></html>'
 
 test('pushstate', function (t) {
   t.plan(1)

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -44,7 +44,7 @@ test('support defaultIndex stream', function (t) {
       }, function (err, resp, body) {
         if (err) t.fail(err)
         t.equal(resp.statusCode, 200)
-        t.equal(body, '<!DOCTYPE html><html lang="en"><head><title>foobar</title><meta charset="utf-8"><link rel="stylesheet" href="main.css"></head><body><script src="app.js"></script></body></html>')
+        t.equal(body, '<!DOCTYPE html><html lang="en" dir="ltr"><head><title>foobar</title><meta charset="utf-8"><link rel="stylesheet" href="main.css"></head><body><script src="app.js"></script></body></html>')
         app.close()
       })
     })
@@ -68,7 +68,7 @@ test('support --title and --css', function (t) {
       }, function (err, resp, body) {
         if (err) t.fail(err)
         t.equal(resp.statusCode, 200)
-        t.equal(body, '<!DOCTYPE html><html lang="en"><head><title>foobar</title><meta charset="utf-8"><link rel="stylesheet" href="main.css"></head><body><script src="app.js"></script></body></html>')
+        t.equal(body, '<!DOCTYPE html><html lang="en" dir="ltr"><head><title>foobar</title><meta charset="utf-8"><link rel="stylesheet" href="main.css"></head><body><script src="app.js"></script></body></html>')
         app.close()
       })
     })

--- a/test/test-static-folders.js
+++ b/test/test-static-folders.js
@@ -28,7 +28,7 @@ test('should serve multiple folders', function (t) {
 test('should find any index.html', function (t) {
   t.plan(1)
 
-  var expected = '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>TWO</title></head><body></body></html>'
+  var expected = '<!DOCTYPE html><html lang="en" dir="ltr"><head><meta charset="UTF-8"><title>TWO</title></head><body></body></html>'
   var app = budo({
     dir: [ path1, path2 ]
   }).on('connect', function (ev) {
@@ -43,7 +43,7 @@ test('should find any index.html', function (t) {
 test('should find the first index.html', function (t) {
   t.plan(1)
 
-  var expected = '<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>THREE</title></head><body></body></html>'
+  var expected = '<!DOCTYPE html><html lang="en" dir="ltr"><head><meta charset="UTF-8"><title>THREE</title></head><body></body></html>'
   var app = budo({
     dir: [ path1, path3, path2 ]
   }).on('connect', function (ev) {


### PR DESCRIPTION
Those are fixes of tests for ES5 version of budo. There were some mismatches caused by update of 'simple-html-index' library. Mostly because option for 'dir' was added.