### PR TITLE
fix path absolute when pushstate has multiple slashes (e.g. '/account/settings')

### DIFF
--- a/lib/map-entry.js
+++ b/lib/map-entry.js
@@ -31,7 +31,7 @@ function mapEntry (file) {
   }
 
   return {
-    url: pathUrl,
+    url: '/' + pathUrl,
     from: pathFrom
   }
 }

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -58,7 +58,7 @@ function budoMiddleware (entryMiddleware, opts) {
 
   // Entry (watchify) middleware
   if (entryMiddleware) {
-    var entryRoute = '/' + urlLib.parse(entrySrc).pathname
+    var entryRoute = urlLib.parse(entrySrc).pathname
     handler.use(function (req, res, next) {
       if (urlTrim(req.url) === urlTrim(entryRoute)) {
         entryMiddleware(req, res, next)


### PR DESCRIPTION
Right now if you do something like this:

``` bash
budo index.js --live --pushstate --open
```

Then in that `index.js`, you have something like this:

``` js
window.history.pushState({}, null, '/account/settings')
```

And then you make a change to that `index.js` or just refresh the page, that `index.js` won't be found. This is because the file is served relatively to the path, but more than likely it should be served absolutely, so it doesn't matter what path you have.

This PR works fine for me, but I'm not familiar enough with the codebase to know if it's right or not. Hopefully it either works or serves as a template for the right solution :-)
