### PR TITLE
Set white-space: normal for error tags

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -24,6 +24,7 @@ function bundleError (message) {
       padding: '20px',
       'box-sizing': 'border-box',
       'word-wrap': 'break-word',
+      'white-space': 'normal',
       'font-size': '16px',
       'font-family': 'monospace',
       margin: '0',


### PR DESCRIPTION
**Problem**: The interesting part of the errors (the file, message, and line number!) always run off the end of the screen and don't get wrapped, effectively making the in-browser errors not very useful without the console. This happens because the computed value for `white-space` is `'pre'`.

<img width="444" alt="screen shot 2016-09-27 at 16 24 01" src="https://cloud.githubusercontent.com/assets/572717/18890383/df729582-84ce-11e6-928a-3ad2218da158.png">

**Proposed solution**: This PR sets `white-space: 'normal'`, which wraps text in the pre tag:

<img width="447" alt="screen shot 2016-09-27 at 16 24 24" src="https://cloud.githubusercontent.com/assets/572717/18890408/0421eab8-84cf-11e6-8c99-4e9dbc8562a0.png">

If I'm missing something or if there's a better solution, do let me know! Love budo! Thanks!