### PR TITLE
Add pushstate-allow and pushstate-disallow

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -49,7 +49,12 @@ function budoMiddleware (entryMiddleware, opts) {
   })
 
   // Re-route for pushState support
-  if (opts.pushstate) handler.use(pushState())
+  if (opts.pushstate || opts.pushstateAllow || opts.pushstateDisallow) {
+    const pushStateOpts = {}
+    if (opts.pushstateAllow) pushStateOpts.allow = opts.pushstateAllow
+    if (opts.pushstateDisallow) pushStateOpts.disallow = opts.pushstateDisallow
+    handler.use(pushState(pushStateOpts))
+  }
 
   // Inject liveReload snippet on response
   var liveInjector = liveReload()

--- a/lib/parse-args.js
+++ b/lib/parse-args.js
@@ -45,7 +45,9 @@ function parseArgs (args, opt) {
       errorHandler: 'error-handler',
       forceDefaultIndex: 'force-default-index',
       'live-port': ['L', 'livePort'],
-      pushstate: 'P'
+      pushstate: 'P',
+      pushstateAllow: 'pushstate-allow',
+      pushstateDisallow: 'pushstate-disallow'
     },
     '--': true
   })

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "bole": "^2.0.0",
     "browserify": "^13.0.1",
     "chokidar": "^1.0.1",
-    "connect-pushstate": "^1.0.0",
+    "connect-pushstate": "^1.1.0",
     "escape-html": "^1.0.3",
     "events": "^1.0.2",
     "garnish": "^5.0.0",

--- a/test/test-pushstate.js
+++ b/test/test-pushstate.js
@@ -6,7 +6,7 @@ var request = require('request')
 var file = path.join(__dirname, 'fixtures', 'app.js')
 var html = '<!DOCTYPE html><html lang="en" dir="ltr"><head><title>budo</title><meta charset="utf-8"></head><body><script src="app.js"></script></body></html>'
 
-test('pushstate', function (t) {
+test('pushstate flag', function (t) {
   t.plan(1)
   var b = budo(file, {
     port: 9966,
@@ -16,6 +16,53 @@ test('pushstate', function (t) {
     request({ uri: ev.uri + '/foobar' }, function (err, resp, body) {
       b.close()
       if (err) return t.fail(err)
+      t.equal(body, html, 'returns home index.html')
+    })
+  })
+})
+
+test('pushstate serve static', function (t) {
+  t.plan(1)
+  var b = budo(file, {
+    port: 9966,
+    pushstate: true,
+    portfind: false
+  }).on('connect', function (ev) {
+    request({ uri: ev.uri + 'app.js' }, function (err, resp, body) {
+      b.close()
+      if (err) return t.fail(err)
+      t.equal(resp.statusCode, 200, '200 OK')
+    })
+  })
+})
+
+test('pushstate-allow', function (t) {
+  t.plan(1)
+  var b = budo(file, {
+    port: 9966,
+    pushstate: true,
+    pushstateAllow: '/app.js',
+    portfind: false
+  }).on('connect', function (ev) {
+    request({ uri: ev.uri + '/app.js' }, function (err, resp, body) {
+      b.close()
+      if (err) return t.fail(err)
+      t.equal(resp.statusCode, 404, '404 Not found')
+    })
+  })
+})
+
+test('pushstate-disallow', function (t) {
+  t.plan(2)
+  var b = budo(file, {
+    port: 9966,
+    pushstateDisallow: '/foo.bar',
+    portfind: false
+  }).on('connect', function (ev) {
+    request({ uri: ev.uri + '/foo.bar' }, function (err, resp, body) {
+      b.close()
+      if (err) return t.fail(err)
+      t.equal(resp.statusCode, 200, '200 OK')
       t.equal(body, html, 'returns home index.html')
     })
   })


### PR DESCRIPTION
As suggested in #150, I'd like to be able to pass the `allow` and `disallow` options to `connect-pushstate`. The way it behaves with this patch applied is

- `--pushstate-allow /foo` marks `/foo` as something that the http server can serve.
- `--pushstate-disallow /foo` marks `/foo` as something that should serve up the root file.

In both cases, `--pushstate` is implied and does not have to be specified.

I bumped `connect-pushstate` to the version that introduces the `disallow` option.

If you want this to behave differently, let me know, and I'll happily make changes.