### PR TITLE
Add force-default-index argument to minimist parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Options:
   --cors           set header to use CORS (Access-Control-Allow-Origin: *)
   --ndjson         print ndjson instead of pretty-printed logs
   --verbose, -v    also include debug messages
+  --force-default-index always serve a generated index.html instead of a static one
   --no-stream      do not print messages to stdout
   --no-debug       do not use inline source maps
   --no-portfind    will not attempt auto-portfinding

--- a/bin/help.txt
+++ b/bin/help.txt
@@ -23,6 +23,7 @@ Options:
   --cors           set header to use CORS (Access-Control-Allow-Origin: *)
   --ndjson         print ndjson instead of pretty-printed logs
   --verbose, -v    also include debug messages
+  --force-default-index always serve a generated index.html instead of a static one
   --no-stream      do not print messages to stdout
   --no-debug       do not use inline source maps
   --no-portfind    will not attempt auto-portfinding

--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -80,6 +80,8 @@ All settings are optional.
 - `errorHandler` (Boolean|Function)
   - whether to include a DOM-based reporter build/syntax errors (default `true`)
   - can be a `reporter(err)` function which takes an Error and returns the new bundle contents
+- `forceDefaultIndex` (Boolean)
+  - whether to always generate index.html instead of serving a static file, if one is present (default: `false`)
 - `pushstate` (Boolean)
   - enable push state support, which defaults 404 routes to the index (default `false`)
   - Recommended you also add something like `<base href="/">` to your HTML `<head>`

--- a/lib/parse-args.js
+++ b/lib/parse-args.js
@@ -8,6 +8,7 @@ function parseArgs (args, opt) {
       'stream',
       'debug',
       'errorHandler',
+      'forceDefaultIndex',
       'open',
       'portfind',
       'ndjson',
@@ -41,6 +42,7 @@ function parseArgs (args, opt) {
       open: 'o',
       watchGlob: [ 'wg', 'watch-glob' ],
       errorHandler: 'error-handler',
+      forceDefaultIndex: 'force-default-index',
       'live-port': ['L', 'livePort'],
       pushstate: 'P'
     },


### PR DESCRIPTION
**The problem**: The `forceDefaultIndex` API option already exists but is not exposed in the CLI. This prevents me from using budo-cli unless I always `rm index.html` first. (example: [index.js](https://github.com/rreusser/demos/tree/master/regl-scan) yields [index.html](http://rickyreusser.com/demos/regl-scan/) in the same directory—which is pretty handy given github web hosting). 

**The solution**: This PR adds a minimist option with hyphenated alias as well as documentation. The default behavior is otherwise unchanged. I have verified this by hand but didn't find end-to-end tests of the CLI or argument parsing to which to add a test.

Let me know if there's any details that need attention or if this is otherwise acceptable/unacceptable. Thanks so much!