### PR TITLE
Add req to defaultIndex args

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -132,7 +132,7 @@ function budoMiddleware (entryMiddleware, opts) {
         title: opts.title,
         css: opts.css,
         base: opts.base === true ? '/' : (opts.base || null)
-      }).pipe(res)
+      }, req).pipe(res)
     } else {
       next()
     }

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -28,9 +28,10 @@ test('should serve on --dir', function (t) {
 })
 
 test('support defaultIndex stream', function (t) {
-  t.plan(3)
+  t.plan(4)
 
-  function html (opt) {
+  function html (opt, req) {
+    t.equal(req.url, '/')
     return defaultHtml({
       entry: opt.entry,
       title: 'foobar',


### PR DESCRIPTION
The [API docs for `defaultIndex`](https://github.com/mattdesl/budo/blob/master/docs/api-usage.md#opts) state the format of a custom function as `fn(params, req)`, so either I'm misinterpreting the docs or it's missing `req` so that the actual call is just `fn(params)`. This PR adds the `req` argument and a corresponding test. Thanks for your time!

Notes:

- current invocation is [here](https://github.com/mattdesl/budo/blob/master/lib/middleware.js#L130-L135)
- simple-html-index [ignores the second argument](https://github.com/mattdesl/simple-html-index/blob/master/index.js#L8), so hopefully shouldn't be a breaking change (though could certainly just skip passing it to that)