### PR TITLE
Update browserify to ^15.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "bole": "^2.0.0",
-    "browserify": "^14.1.0",
+    "browserify": "^15.0.0",
     "chokidar": "^1.0.1",
     "connect-pushstate": "^1.1.0",
     "escape-html": "^1.0.3",


### PR DESCRIPTION
Budo will no longer crash on code with spread operators making more in line with node these days, but drops support for node < 4.0 maybe. See https://github.com/browserify/browserify/pull/1794#pullrequestreview-87403598 for details.  <3 Budo.
