### PR TITLE
Squash fsevents errors (which are not errors on Linux)

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -237,6 +237,10 @@ function bundleError (message, cwd, rootDirName) {
 }
 
 function errorHandler (err, cwd, rootDirName) {
+  // Squash the fsevents error from Chokidar as it is not really an
+  // error on Linux systems and would not be an issue on macOS.
+  if (err.message.indexOf("Cannot find module 'fsevents'") > -1) return
+
   console.error('%s', err)
   var msgStr = stripAnsi(err.message)
   var params = [


### PR DESCRIPTION
On non-macOS systems, the following error is logged to the console on every rebuild:

```bash
Error: Cannot find module 'fsevents' from '…/node_modules/chokidar/lib'
```

[fsevents](https://github.com/strongloop/fsevents) is a macOS-only module and should not be causing errors on other platforms.

This PR squashes that specific error.