### PR TITLE
Add file types option to directory live reload example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ budo index.js --live -- -t babelify
 budo index.js --ssl --cors
 
 # LiveReload public directory without any bundling
-budo --dir public/ --live
+# Add all extensions of file types you want to trigger reloads
+budo --dir public/ --wg **/*.{html,css,js} --live
 ```
 
 Then open [http://localhost:9966/](http://localhost:9966/) to see the content in action.


### PR DESCRIPTION
Minor docs edit to address potential confusion as described in https://github.com/mattdesl/budo/issues/245

Budo's a great live-reload server! I just think this simple use case should be a bit more obvious. Not using an html file at all seems a bit of an odd case to be the one primarily featured, but hopefully this edit helps.